### PR TITLE
Feat: Støtte for aura token generering i dev.

### DIFF
--- a/.deploy/fp/dev-gcp-teamforeldrepenger.json
+++ b/.deploy/fp/dev-gcp-teamforeldrepenger.json
@@ -16,8 +16,11 @@
   "groups": [
     "f1b82579-c5b5-4617-9673-8ace5ff67f63"
   ],
-  "dbTier": "db-f1-micro",
-  "dbDiskAutoresize": "false",
-  "dbHighAvailability": "false",
-  "dbPointInTimeRecovery": "false"
+  "db": {
+    "dbTier": "db-f1-micro",
+    "dbDiskAutoresize": "false",
+    "dbHighAvailability": "false",
+    "dbPointInTimeRecovery": "false"
+  },
+  "devOnly": "true"
 }

--- a/.deploy/fp/naiserator.yaml
+++ b/.deploy/fp/naiserator.yaml
@@ -53,10 +53,10 @@ spec:
         databases:
           - name: fpinntektsmelding
             envVarPrefix: DB
-        tier: {{dbTier}}
-        diskAutoresize: {{dbDiskAutoresize}}
-        highAvailability: {{dbHighAvailability}}
-        pointInTimeRecovery: {{dbPointInTimeRecovery}}
+        tier: {{db.dbTier}}
+        diskAutoresize: {{db.dbDiskAutoresize}}
+        highAvailability: {{db.dbHighAvailability}}
+        pointInTimeRecovery: {{db.dbPointInTimeRecovery}}
         collation: nb_NO.UTF8
   secureLogs:
     enabled: true
@@ -75,6 +75,7 @@ spec:
   accessPolicy:
     inbound:
       rules:
+        - application: fpinntektsmelding-frontend
         - application: fp-swagger
           permissions:
             scopes:
@@ -82,7 +83,14 @@ spec:
         - application: fpsak
           namespace: teamforeldrepenger
           cluster: {{environment}}-fss
-        - application: fpinntektsmelding-frontend
+      {{#if devOnly}}
+        - application: azure-token-generator
+          namespace: aura
+          cluster: dev-gcp
+        - application: tokenx-token-generator
+          namespace: aura
+          cluster: dev-gcp
+      {{/if}}
     outbound:
       rules:
         - application: notifikasjon-produsent-api
@@ -95,5 +103,8 @@ spec:
         - host: team-inntekt-proxy.{{environment}}-fss-pub.nais.io
         - host: ereg-services.{{environment}}-fss-pub.nais.io
         - host: fpsak-api.{{environment}}-fss-pub.nais.io
+      {{#if devOnly}}
         - host: dokarkiv-q2.{{environment}}-fss-pub.nais.io
-        - host: dokarkiv.{{environment}}-fss-pub.nais.io
+      {{#else}}
+         - host: dokarkiv.{{environment}}-fss-pub.nais.io
+      {{/if}}

--- a/.deploy/fp/prod-gcp-teamforeldrepenger.json
+++ b/.deploy/fp/prod-gcp-teamforeldrepenger.json
@@ -13,8 +13,10 @@
   "groups": [
     "0d226374-4748-4367-a38a-062dcad70034"
   ],
-  "dbTier": "TODO",
-  "dbDiskAutoresize": "true",
-  "dbHighAvailability": "true",
-  "dbPointInTimeRecovery": "true"
+  "db": {
+    "dbTier": "TODO",
+    "dbDiskAutoresize": "true",
+    "dbHighAvailability": "true",
+    "dbPointInTimeRecovery": "true"
+  }
 }


### PR DESCRIPTION
Det blir da mulig å innhente en gyldig tokenX token for en arbeidsgiver med 
`https://tokenx-token-generator.intern.dev.nav.no/api/obo?aud=dev-gcp:teamforeldrepenger:fpinntektsmelding`

og et gyldig Azure token for kall fra fagsak med:

-  Brukerkontekst: `https://azure-token-generator.intern.dev.nav.no/api/obo?aud=dev-gcp:teamforeldrepenger:fpinntektsmelding`
- Systemkontekst: `https://azure-token-generator.intern.dev.nav.no/api/m2m?aud=dev-gcp:teamforeldrepenger:fpinntektsmelding`

Kan brukes i f.eks. postman for å simulere frontend kall til backend eller fagsystemkall til IM-backen.

https://doc.nais.io/auth/tokenx/how-to/generate/
https://doc.nais.io/auth/entra-id/how-to/generate/