### PR TITLE
Fikser GeneralExceptionMapperTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,7 @@
                             junit.jupiter.execution.parallel.mode.default = concurrent
                         </configurationParameters>
                     </properties>
+                    <argLine>@{argLine} ${argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -291,6 +292,11 @@
                             <outputDirectory>${project.basedir}/target/lib/</outputDirectory>
                             <includeScope>runtime</includeScope>
                         </configuration>
+                    </execution>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -270,12 +270,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <properties>
-                        <configurationParameters>
-                            junit.jupiter.execution.parallel.enabled = true
-                            junit.jupiter.execution.parallel.mode.default = concurrent
-                        </configurationParameters>
-                    </properties>
                     <argLine>@{argLine} ${argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
                 </configuration>
             </plugin>

--- a/src/test/java/no/nav/familie/inntektsmelding/server/exceptions/GeneralRestExceptionMapperTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/server/exceptions/GeneralRestExceptionMapperTest.java
@@ -22,7 +22,7 @@ class GeneralRestExceptionMapperTest {
     private final GeneralRestExceptionMapper exceptionMapper = new GeneralRestExceptionMapper();
 
     @BeforeEach
-    void beforeEach() {
+    void setUp() {
         logSniffer = MemoryAppender.sniff(GeneralRestExceptionMapper.class);
     }
 

--- a/src/test/java/no/nav/familie/inntektsmelding/server/exceptions/GeneralRestExceptionMapperTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/server/exceptions/GeneralRestExceptionMapperTest.java
@@ -2,13 +2,13 @@ package no.nav.familie.inntektsmelding.server.exceptions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import ch.qos.logback.classic.Level;
 import no.nav.vedtak.exception.FunksjonellException;
@@ -19,6 +19,8 @@ import no.nav.vedtak.log.util.MemoryAppender;
 @Execution(ExecutionMode.SAME_THREAD)
 class GeneralRestExceptionMapperTest {
 
+    private static final Logger LOG = LoggerFactory.getLogger(GeneralRestExceptionMapperTest.class);
+
     private static MemoryAppender logSniffer;
 
     private final GeneralRestExceptionMapper exceptionMapper = new GeneralRestExceptionMapper();
@@ -26,20 +28,12 @@ class GeneralRestExceptionMapperTest {
     @BeforeAll
     static void beforeAll() {
         System.setProperty("slf4j.detectLoggerNameMismatch", "true");
-    }
-
-    @AfterAll
-    static void afterAll() {
-        System.clearProperty("slf4j.detectLoggerNameMismatch");
-    }
-
-    @BeforeEach
-    void setUp() {
         logSniffer = MemoryAppender.sniff(GeneralRestExceptionMapper.class);
     }
 
     @AfterEach
     void afterEach() {
+        System.clearProperty("slf4j.detectLoggerNameMismatch");
         logSniffer.reset();
     }
 

--- a/src/test/java/no/nav/familie/inntektsmelding/server/exceptions/GeneralRestExceptionMapperTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/server/exceptions/GeneralRestExceptionMapperTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import ch.qos.logback.classic.Level;
 import no.nav.vedtak.exception.FunksjonellException;
@@ -16,6 +18,8 @@ import no.nav.vedtak.log.util.MemoryAppender;
 
 @Execution(ExecutionMode.SAME_THREAD)
 class GeneralRestExceptionMapperTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GeneralRestExceptionMapperTest.class);
 
     private static MemoryAppender logSniffer;
 

--- a/src/test/java/no/nav/familie/inntektsmelding/server/exceptions/GeneralRestExceptionMapperTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/server/exceptions/GeneralRestExceptionMapperTest.java
@@ -2,9 +2,10 @@ package no.nav.familie.inntektsmelding.server.exceptions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -22,6 +23,16 @@ class GeneralRestExceptionMapperTest {
 
     private final GeneralRestExceptionMapper exceptionMapper = new GeneralRestExceptionMapper();
 
+    @BeforeAll
+    static void beforeAll() {
+        System.setProperty("slf4j.detectLoggerNameMismatch", "true");
+    }
+
+    @AfterAll
+    static void afterAll() {
+        System.clearProperty("slf4j.detectLoggerNameMismatch");
+    }
+
     @BeforeEach
     void setUp() {
         logSniffer = MemoryAppender.sniff(GeneralRestExceptionMapper.class);
@@ -32,7 +43,6 @@ class GeneralRestExceptionMapperTest {
         logSniffer.reset();
     }
 
-    @Disabled
     @Test
     void skalIkkeMappeManglerTilgangFeil() {
         var response = exceptionMapper.toResponse(manglerTilgangFeil());
@@ -46,7 +56,6 @@ class GeneralRestExceptionMapperTest {
         assertThat(logSniffer.search("ManglerTilgangFeilmeldingKode", Level.WARN)).isEmpty();
     }
 
-    @Disabled
     @Test
     void skalMappeFunksjonellFeil() {
         var response = exceptionMapper.toResponse(funksjonellFeil());
@@ -60,7 +69,6 @@ class GeneralRestExceptionMapperTest {
         assertThat(logSniffer.search("en funksjonell feilmelding", Level.WARN)).hasSize(1);
     }
 
-    @Disabled
     @Test
     void skalMappeVLException() {
         var response = exceptionMapper.toResponse(tekniskFeil());
@@ -73,7 +81,6 @@ class GeneralRestExceptionMapperTest {
         assertThat(logSniffer.search("en teknisk feilmelding", Level.WARN)).hasSize(1);
     }
 
-    @Disabled
     @Test
     void skalMappeWrappedGenerellFeil() {
         var feilmelding = "en helt generell feil";
@@ -89,7 +96,6 @@ class GeneralRestExceptionMapperTest {
         assertThat(logSniffer.search("TEKST", Level.WARN)).hasSize(1);
     }
 
-    @Disabled
     @Test
     void skalMappeWrappedFeilUtenCause() {
         var feilmelding = "en helt generell feil";
@@ -104,7 +110,6 @@ class GeneralRestExceptionMapperTest {
         assertThat(logSniffer.search(feilmelding, Level.WARN)).hasSize(1);
     }
 
-    @Disabled
     @Test
     void skalMappeGenerellFeil() {
         var feilmelding = "en helt generell feil";

--- a/src/test/java/no/nav/familie/inntektsmelding/server/exceptions/GeneralRestExceptionMapperTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/server/exceptions/GeneralRestExceptionMapperTest.java
@@ -7,8 +7,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import ch.qos.logback.classic.Level;
 import no.nav.vedtak.exception.FunksjonellException;
@@ -19,21 +17,17 @@ import no.nav.vedtak.log.util.MemoryAppender;
 @Execution(ExecutionMode.SAME_THREAD)
 class GeneralRestExceptionMapperTest {
 
-    private static final Logger LOG = LoggerFactory.getLogger(GeneralRestExceptionMapperTest.class);
-
     private static MemoryAppender logSniffer;
 
     private final GeneralRestExceptionMapper exceptionMapper = new GeneralRestExceptionMapper();
 
     @BeforeAll
     static void beforeAll() {
-        System.setProperty("slf4j.detectLoggerNameMismatch", "true");
         logSniffer = MemoryAppender.sniff(GeneralRestExceptionMapper.class);
     }
 
     @AfterEach
     void afterEach() {
-        System.clearProperty("slf4j.detectLoggerNameMismatch");
         logSniffer.reset();
     }
 

--- a/src/test/java/no/nav/familie/inntektsmelding/server/exceptions/GeneralRestExceptionMapperTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/server/exceptions/GeneralRestExceptionMapperTest.java
@@ -3,12 +3,10 @@ package no.nav.familie.inntektsmelding.server.exceptions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import ch.qos.logback.classic.Level;
 import no.nav.vedtak.exception.FunksjonellException;
@@ -19,14 +17,12 @@ import no.nav.vedtak.log.util.MemoryAppender;
 @Execution(ExecutionMode.SAME_THREAD)
 class GeneralRestExceptionMapperTest {
 
-    private static final Logger LOG = LoggerFactory.getLogger(GeneralRestExceptionMapperTest.class);
-
     private static MemoryAppender logSniffer;
 
     private final GeneralRestExceptionMapper exceptionMapper = new GeneralRestExceptionMapper();
 
-    @BeforeAll
-    static void beforeAll() {
+    @BeforeEach
+    void beforeEach() {
         logSniffer = MemoryAppender.sniff(GeneralRestExceptionMapper.class);
     }
 
@@ -37,40 +33,40 @@ class GeneralRestExceptionMapperTest {
 
     @Test
     void skalIkkeMappeManglerTilgangFeil() {
-        var response = exceptionMapper.toResponse(manglerTilgangFeil());
+        try (var response = exceptionMapper.toResponse(manglerTilgangFeil())) {
+            assertThat(response.getStatus()).isEqualTo(403);
+            assertThat(response.getEntity()).isInstanceOf(FeilDto.class);
+            var feilDto = (FeilDto) response.getEntity();
 
-        assertThat(response.getStatus()).isEqualTo(403);
-        assertThat(response.getEntity()).isInstanceOf(FeilDto.class);
-        var feilDto = (FeilDto) response.getEntity();
-
-        assertThat(feilDto.type()).isEqualTo(FeilType.MANGLER_TILGANG_FEIL);
-        assertThat(feilDto.feilmelding()).contains("ManglerTilgangFeilmeldingKode");
-        assertThat(logSniffer.search("ManglerTilgangFeilmeldingKode", Level.WARN)).isEmpty();
+            assertThat(feilDto.type()).isEqualTo(FeilType.MANGLER_TILGANG_FEIL);
+            assertThat(feilDto.feilmelding()).contains("ManglerTilgangFeilmeldingKode");
+            assertThat(logSniffer.search("ManglerTilgangFeilmeldingKode", Level.WARN)).isEmpty();
+        }
     }
 
     @Test
     void skalMappeFunksjonellFeil() {
-        var response = exceptionMapper.toResponse(funksjonellFeil());
+        try (var response = exceptionMapper.toResponse(funksjonellFeil())) {
+            assertThat(response.getEntity()).isInstanceOf(FeilDto.class);
+            var feilDto = (FeilDto) response.getEntity();
 
-        assertThat(response.getEntity()).isInstanceOf(FeilDto.class);
-        var feilDto = (FeilDto) response.getEntity();
-
-        assertThat(feilDto.feilmelding()).contains("FUNK_FEIL");
-        assertThat(feilDto.feilmelding()).contains("en funksjonell feilmelding");
-        assertThat(feilDto.feilmelding()).contains("et løsningsforslag");
-        assertThat(logSniffer.search("en funksjonell feilmelding", Level.WARN)).hasSize(1);
+            assertThat(feilDto.feilmelding()).contains("FUNK_FEIL");
+            assertThat(feilDto.feilmelding()).contains("en funksjonell feilmelding");
+            assertThat(feilDto.feilmelding()).contains("et løsningsforslag");
+            assertThat(logSniffer.search("en funksjonell feilmelding", Level.WARN)).hasSize(1);
+        }
     }
 
     @Test
     void skalMappeVLException() {
-        var response = exceptionMapper.toResponse(tekniskFeil());
+        try (var response = exceptionMapper.toResponse(tekniskFeil())) {
+            assertThat(response.getEntity()).isInstanceOf(FeilDto.class);
+            var feilDto = (FeilDto) response.getEntity();
 
-        assertThat(response.getEntity()).isInstanceOf(FeilDto.class);
-        var feilDto = (FeilDto) response.getEntity();
-
-        assertThat(feilDto.feilmelding()).contains("TEK_FEIL");
-        assertThat(feilDto.feilmelding()).contains("en teknisk feilmelding");
-        assertThat(logSniffer.search("en teknisk feilmelding", Level.WARN)).hasSize(1);
+            assertThat(feilDto.feilmelding()).contains("TEK_FEIL");
+            assertThat(feilDto.feilmelding()).contains("en teknisk feilmelding");
+            assertThat(logSniffer.search("en teknisk feilmelding", Level.WARN)).hasSize(1);
+        }
     }
 
     @Test
@@ -78,28 +74,27 @@ class GeneralRestExceptionMapperTest {
         var feilmelding = "en helt generell feil";
         var generellFeil = new RuntimeException(feilmelding);
 
-        var response = exceptionMapper.toResponse(new TekniskException("KODE", "TEKST", generellFeil));
+        try (var response = exceptionMapper.toResponse(new TekniskException("KODE", "TEKST", generellFeil))) {
+            assertThat(response.getStatus()).isEqualTo(500);
+            assertThat(response.getEntity()).isInstanceOf(FeilDto.class);
+            var feilDto = (FeilDto) response.getEntity();
 
-        assertThat(response.getStatus()).isEqualTo(500);
-        assertThat(response.getEntity()).isInstanceOf(FeilDto.class);
-        var feilDto = (FeilDto) response.getEntity();
-
-        assertThat(feilDto.feilmelding()).contains("TEKST");
-        assertThat(logSniffer.search("TEKST", Level.WARN)).hasSize(1);
+            assertThat(feilDto.feilmelding()).contains("TEKST");
+            assertThat(logSniffer.search("TEKST", Level.WARN)).hasSize(1);
+        }
     }
 
     @Test
     void skalMappeWrappedFeilUtenCause() {
         var feilmelding = "en helt generell feil";
+        try (var response = exceptionMapper.toResponse(new TekniskException("KODE", feilmelding))) {
+            assertThat(response.getStatus()).isEqualTo(500);
+            assertThat(response.getEntity()).isInstanceOf(FeilDto.class);
+            var feilDto = (FeilDto) response.getEntity();
 
-        var response = exceptionMapper.toResponse(new TekniskException("KODE", feilmelding));
-
-        assertThat(response.getStatus()).isEqualTo(500);
-        assertThat(response.getEntity()).isInstanceOf(FeilDto.class);
-        var feilDto = (FeilDto) response.getEntity();
-
-        assertThat(feilDto.feilmelding()).contains(feilmelding);
-        assertThat(logSniffer.search(feilmelding, Level.WARN)).hasSize(1);
+            assertThat(feilDto.feilmelding()).contains(feilmelding);
+            assertThat(logSniffer.search(feilmelding, Level.WARN)).hasSize(1);
+        }
     }
 
     @Test
@@ -107,16 +102,15 @@ class GeneralRestExceptionMapperTest {
         var feilmelding = "en helt generell feil";
         RuntimeException generellFeil = new IllegalArgumentException(feilmelding);
 
-        var response = exceptionMapper.toResponse(generellFeil);
+        try (var response = exceptionMapper.toResponse(generellFeil)) {
+            assertThat(response.getStatus()).isEqualTo(500);
+            assertThat(response.getEntity()).isInstanceOf(FeilDto.class);
+            var feilDto = (FeilDto) response.getEntity();
 
-        assertThat(response.getStatus()).isEqualTo(500);
-        assertThat(response.getEntity()).isInstanceOf(FeilDto.class);
-        var feilDto = (FeilDto) response.getEntity();
-
-        assertThat(feilDto.feilmelding()).contains(feilmelding);
-        assertThat(logSniffer.search(feilmelding, Level.WARN)).hasSize(1);
+            assertThat(feilDto.feilmelding()).contains(feilmelding);
+            assertThat(logSniffer.search(feilmelding, Level.WARN)).hasSize(1);
+        }
     }
-
 
     private static FunksjonellException funksjonellFeil() {
         return new FunksjonellException("FUNK_FEIL", "en funksjonell feilmelding", "et løsningsforslag");

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -7,6 +7,17 @@
         </encoder>
     </appender>
 
+    <appender name="secureLogger" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%-5level] [%thread] %logger{5} - [%X{consumerId}, %X{callId}, %X{userId}] - %m%n</pattern>
+            <!-- pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern -->
+        </encoder>
+    </appender>
+
+    <logger name="secureLogger" level="INFO" additivity="false">
+        <appender-ref ref="secureLogger" />
+    </logger>
+
     <logger name="no.nav" level="${log.level.no.nav:-INFO}" />
 
     <logger name="org.hibernate.SQL" level="${org.hibernate.SQL:-WARN}" />


### PR DESCRIPTION
Fikser feilen med denne testen. Årsaken til feilen er at Logback prøver å replaye alt som ble logget i init fasen om man kjører i et multithreaded miljø - https://www.slf4j.org/codes.html#replay
Jeg har slått av multithreading ved bygging om man ikke har noe mot. Det beste er å finne ut av dette. 

Ekstra ting:
- Legger inn test konfig for secureLogger
- Legger inn Mockito som javaagent som beskrevet her: https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#0.3
- Oppdatering av biblioteker.