### PR TITLE
Prøver å fikse ferdigstilling av forespørsel

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselRepository.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselRepository.java
@@ -81,6 +81,13 @@ public class ForespørselRepository {
         }
     }
 
+    public ForespørselEntitet ferdigstillForespørsel(ForespørselEntitet entitet) {
+        entitet.setStatus(ForespørselStatus.FERDIG);
+        entityManager.persist(entitet);
+        entityManager.flush();
+        return entitet;
+    }
+
     public void ferdigstillForespørsel(String arbeidsgiverNotifikasjonSakId) {
         var query = entityManager.createQuery("FROM ForespørselEntitet where sakId = :SAK_ID", ForespørselEntitet.class)
             .setParameter("SAK_ID", arbeidsgiverNotifikasjonSakId);

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImpl.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImpl.java
@@ -97,8 +97,7 @@ class ForespørselBehandlingTjenesteImpl implements ForespørselBehandlingTjenes
             arbeidsgiverNotifikasjon.oppdaterSakTilleggsinformasjon(foresporsel.getArbeidsgiverNotifikasjonSakId(),
                 ForespørselTekster.lagTilleggsInformasjon(årsak));
         }
-        forespørselTjeneste.ferdigstillForespørsel(foresporsel.getArbeidsgiverNotifikasjonSakId()); // Oppdaterer status i forespørsel
-        return foresporsel;
+        return forespørselTjeneste.ferdigstillForespørsel(foresporsel); // Oppdaterer status i forespørsel
     }
 
     @Override

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTjeneste.java
@@ -51,6 +51,10 @@ public class ForespørselTjeneste {
         forespørselRepository.ferdigstillForespørsel(arbeidsgiverNotifikasjonSakId);
     }
 
+    public ForespørselEntitet ferdigstillForespørsel(ForespørselEntitet entitet) {
+        return forespørselRepository.ferdigstillForespørsel(entitet);
+    }
+
     public void settForespørselTilUtgått(String arbeidsgiverNotifikasjonSakId) {
         forespørselRepository.settForespørselTilUtgått(arbeidsgiverNotifikasjonSakId);
     }


### PR DESCRIPTION
Status på forespørsel blir ikke oppdatert til FERDIG. Jeg mistenter at det er noe muffens i db-kallene her. Kanskje er det at entiteten hentes ut to ganger i stacken som gjør at oppdateringen ikke blir gjort. Prøver å løse det ved å oppdatere entiteten som allerede er hentet ut stedenfor å hente den ut på nytt for oppdatering, og returnerer oppdatert entitet. Hvis dette funker så bør det sikkert skrives penere.