### PR TITLE
Oppdaterer forespørsler med prosesstasks for bedre feilhåndtering

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -29,10 +29,20 @@ public interface ForespørselBehandlingTjeneste {
 
     Optional<ForespørselEntitet> hentForespørsel(UUID forespørselUUID);
 
+    List<ForespørselEntitet> hentForespørslerForFagsak(SaksnummerDto fagsakSaksnummer,
+                                                       OrganisasjonsnummerDto orgnummerDto,
+                                                       LocalDate skjæringstidspunkt);
+
     void oppdaterForespørsler(Ytelsetype ytelsetype,
                               AktørIdEntitet aktørId,
                               Map<LocalDate, List<OrganisasjonsnummerDto>> organisasjonerPerSkjæringstidspunkt,
                               SaksnummerDto fagsakSaksnummer);
+
+    void opprettForespørsel(Ytelsetype ytelsetype,
+                            AktørIdEntitet aktørId,
+                            SaksnummerDto fagsakSaksnummer,
+                            OrganisasjonsnummerDto organisasjonsnummer,
+                            LocalDate skjæringstidspunkt);
 
     void lukkForespørsel(SaksnummerDto fagsakSaksnummer, OrganisasjonsnummerDto orgnummerDto, LocalDate skjæringstidspunkt);
 
@@ -40,4 +50,6 @@ public interface ForespørselBehandlingTjeneste {
 
 
     void settForespørselTilUtgått(SaksnummerDto saksnummerDto, OrganisasjonsnummerDto orgnummer, LocalDate skjæringstidspunkt);
+
+    void settForespørselTilUtgått(ForespørselEntitet eksisterendeForespørsel);
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImpl.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImpl.java
@@ -116,12 +116,7 @@ class ForespørselBehandlingTjenesteImpl implements ForespørselBehandlingTjenes
                     .findFirst();
 
                 if (eksisterendeForespørsel.isEmpty()) {
-                    var opprettForespørselTask = ProsessTaskData.forProsessTask(OpprettForespørselTask.class);
-                    opprettForespørselTask.setProperty(OpprettForespørselTask.YTELSETYPE, ytelsetype.name());
-                    opprettForespørselTask.setProperty(OpprettForespørselTask.AKTØR_ID, aktørId.getAktørId());
-                    opprettForespørselTask.setProperty(OpprettForespørselTask.FAGSAK_SAKSNUMMER, fagsakSaksnummer.saksnr());
-                    opprettForespørselTask.setProperty(OpprettForespørselTask.ORGNR, organisasjon.orgnr());
-                    opprettForespørselTask.setProperty(OpprettForespørselTask.STP, skjæringstidspunkt.toString());
+                    var opprettForespørselTask = OpprettForespørselTask.lagTaskData(ytelsetype, aktørId, fagsakSaksnummer, organisasjon, skjæringstidspunkt);
                     taskGruppe.addNesteParallell(opprettForespørselTask);
                 }
             });

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImpl.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImpl.java
@@ -139,8 +139,12 @@ class ForespørselBehandlingTjenesteImpl implements ForespørselBehandlingTjenes
             }
         });
 
-        taskGruppe.setCallIdFraEksisterende();
-        prosessTaskTjeneste.lagre(taskGruppe);
+        if (!taskGruppe.getTasks().isEmpty()) {
+            taskGruppe.setCallIdFraEksisterende();
+            prosessTaskTjeneste.lagre(taskGruppe);
+        } else {
+            LOG.info("Ingen oppdatering er nødvendig for saksnr: {}", fagsakSaksnummer);
+        }
     }
 
     @Override

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImpl.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImpl.java
@@ -15,6 +15,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.task.OpprettForespørselTask;
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.task.SettForespørselTilUtgåttTask;
 import no.nav.familie.inntektsmelding.integrasjoner.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjon;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
 import no.nav.familie.inntektsmelding.koder.ForespørselStatus;
@@ -25,6 +27,9 @@ import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
 import no.nav.familie.inntektsmelding.typer.dto.SaksnummerDto;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
 import no.nav.foreldrepenger.konfig.Environment;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskGruppe;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
 @ApplicationScoped
 class ForespørselBehandlingTjenesteImpl implements ForespørselBehandlingTjeneste {
@@ -35,15 +40,18 @@ class ForespørselBehandlingTjenesteImpl implements ForespørselBehandlingTjenes
     private ForespørselTjeneste forespørselTjeneste;
     private ArbeidsgiverNotifikasjon arbeidsgiverNotifikasjon;
     private PersonTjeneste personTjeneste;
+    private ProsessTaskTjeneste prosessTaskTjeneste;
     private String inntektsmeldingSkjemaLenke;
 
     @Inject
     public ForespørselBehandlingTjenesteImpl(ForespørselTjeneste forespørselTjeneste,
                                              ArbeidsgiverNotifikasjon arbeidsgiverNotifikasjon,
-                                             PersonTjeneste personTjeneste) {
+                                             PersonTjeneste personTjeneste,
+                                             ProsessTaskTjeneste prosessTaskTjeneste) {
         this.forespørselTjeneste = forespørselTjeneste;
         this.arbeidsgiverNotifikasjon = arbeidsgiverNotifikasjon;
         this.personTjeneste = personTjeneste;
+        this.prosessTaskTjeneste = prosessTaskTjeneste;
         this.inntektsmeldingSkjemaLenke = ENV.getProperty("inntektsmelding.skjema.lenke", "https://arbeidsgiver.intern.dev.nav.no/fp-im-dialog");
     }
 
@@ -60,7 +68,7 @@ class ForespørselBehandlingTjenesteImpl implements ForespørselBehandlingTjenes
             return ForespørselResultat.IKKE_OPPRETTET_FINNES_ALLEREDE_ÅPEN;
         }
 
-        opprettForespørselOppgave(ytelsetype, aktørId, fagsakSaksnummer, organisasjonsnummer, skjæringstidspunkt);
+        opprettForespørsel(ytelsetype, aktørId, fagsakSaksnummer, organisasjonsnummer, skjæringstidspunkt);
         return ForespørselResultat.FORESPØRSEL_OPPRETTET;
     }
 
@@ -95,7 +103,8 @@ class ForespørselBehandlingTjenesteImpl implements ForespørselBehandlingTjenes
                                      AktørIdEntitet aktørId,
                                      Map<LocalDate, List<OrganisasjonsnummerDto>> organisasjonerPerSkjæringstidspunkt,
                                      SaksnummerDto fagsakSaksnummer) {
-        var eksisterendeForespørsler = forespørselTjeneste.finnForespørslerForSak(fagsakSaksnummer);
+        final var eksisterendeForespørsler = forespørselTjeneste.finnForespørslerForFagsak(fagsakSaksnummer);
+        final var taskGruppe = new ProsessTaskGruppe();
 
         // Oppretter forespørsler for alle skjæringstidspunkter som ikke allerede er opprettet
         organisasjonerPerSkjæringstidspunkt.forEach((skjæringstidspunkt, organisasjoner) -> {
@@ -103,16 +112,17 @@ class ForespørselBehandlingTjenesteImpl implements ForespørselBehandlingTjenes
                 var eksisterendeForespørsel = eksisterendeForespørsler.stream()
                     .filter(forespørsel -> forespørsel.getSkjæringstidspunkt().equals(skjæringstidspunkt))
                     .filter(forespørsel -> forespørsel.getOrganisasjonsnummer().equals(organisasjon.orgnr()))
+                    .filter(forespørsel -> !forespørsel.getStatus().equals(ForespørselStatus.UTGÅTT))
                     .findFirst();
 
                 if (eksisterendeForespørsel.isEmpty()) {
-                    opprettForespørselOppgave(ytelsetype, aktørId, fagsakSaksnummer, organisasjon, skjæringstidspunkt);
-                    var msg = String.format("Oppretter forespørsel, orgnr: %s, stp: %s, saksnr: %s, ytelse: %s",
-                        organisasjon.orgnr(),
-                        skjæringstidspunkt,
-                        fagsakSaksnummer.saksnr(),
-                        ytelsetype);
-                    LOG.info(msg);
+                    var opprettForespørselTask = ProsessTaskData.forProsessTask(OpprettForespørselTask.class);
+                    opprettForespørselTask.setProperty(OpprettForespørselTask.YTELSETYPE, ytelsetype.name());
+                    opprettForespørselTask.setProperty(OpprettForespørselTask.AKTØR_ID, aktørId.getAktørId());
+                    opprettForespørselTask.setProperty(OpprettForespørselTask.FAGSAK_SAKSNUMMER, fagsakSaksnummer.saksnr());
+                    opprettForespørselTask.setProperty(OpprettForespørselTask.ORGNR, organisasjon.orgnr());
+                    opprettForespørselTask.setProperty(OpprettForespørselTask.STP, skjæringstidspunkt.toString());
+                    taskGruppe.addNesteParallell(opprettForespørselTask);
                 }
             });
         });
@@ -123,12 +133,18 @@ class ForespørselBehandlingTjenesteImpl implements ForespørselBehandlingTjenes
                 eksisterendeForespørsel);
 
             if (!trengerEksisterendeForespørsel && eksisterendeForespørsel.getStatus() == ForespørselStatus.UNDER_BEHANDLING) {
-                setterForespørselTilUtgått(eksisterendeForespørsel);
+                var settForespørselTilUtgåttTask = ProsessTaskData.forProsessTask(SettForespørselTilUtgåttTask.class);
+                settForespørselTilUtgåttTask.setProperty(SettForespørselTilUtgåttTask.FORESPØRSEL_UUID, eksisterendeForespørsel.getUuid().toString());
+                taskGruppe.addNesteParallell(settForespørselTilUtgåttTask);
             }
         });
+
+        taskGruppe.setCallIdFraEksisterende();
+        prosessTaskTjeneste.lagre(taskGruppe);
     }
 
-    private void setterForespørselTilUtgått(ForespørselEntitet eksisterendeForespørsel) {
+    @Override
+    public void settForespørselTilUtgått(ForespørselEntitet eksisterendeForespørsel) {
         arbeidsgiverNotifikasjon.oppgaveUtgått(eksisterendeForespørsel.getOppgaveId(), OffsetDateTime.now());
         arbeidsgiverNotifikasjon.ferdigstillSak(eksisterendeForespørsel.getArbeidsgiverNotifikasjonSakId()); // Oppdaterer status i arbeidsgiver-notifikasjon
         arbeidsgiverNotifikasjon.oppdaterSakTilleggsinformasjon(eksisterendeForespørsel.getArbeidsgiverNotifikasjonSakId(),
@@ -156,11 +172,19 @@ class ForespørselBehandlingTjenesteImpl implements ForespørselBehandlingTjenes
         return orgnrFraRequestForStp.contains(eksisterendeForespørsel.getOrganisasjonsnummer());
     }
 
-    private void opprettForespørselOppgave(Ytelsetype ytelsetype,
-                                           AktørIdEntitet aktørId,
-                                           SaksnummerDto fagsakSaksnummer,
-                                           OrganisasjonsnummerDto organisasjonsnummer,
-                                           LocalDate skjæringstidspunkt) {
+    @Override
+    public void opprettForespørsel(Ytelsetype ytelsetype,
+                                   AktørIdEntitet aktørId,
+                                   SaksnummerDto fagsakSaksnummer,
+                                   OrganisasjonsnummerDto organisasjonsnummer,
+                                   LocalDate skjæringstidspunkt) {
+        var msg = String.format("Oppretter forespørsel, orgnr: %s, stp: %s, saksnr: %s, ytelse: %s",
+            organisasjonsnummer.orgnr(),
+            skjæringstidspunkt,
+            fagsakSaksnummer.saksnr(),
+            ytelsetype);
+        LOG.info(msg);
+
         var uuid = forespørselTjeneste.opprettForespørsel(skjæringstidspunkt, ytelsetype, aktørId, organisasjonsnummer, fagsakSaksnummer);
         var person = personTjeneste.hentPersonInfoFraAktørId(aktørId, ytelsetype);
         var merkelapp = ForespørselTekster.finnMerkelapp(ytelsetype);
@@ -185,6 +209,7 @@ class ForespørselBehandlingTjenesteImpl implements ForespørselBehandlingTjenes
         forespørselTjeneste.setOppgaveId(uuid, oppgaveId);
     }
 
+    @Override
     public void lukkForespørsel(SaksnummerDto fagsakSaksnummer, OrganisasjonsnummerDto orgnummerDto, LocalDate skjæringstidspunkt) {
         var forespørsler = hentÅpneForespørslerForFagsak(fagsakSaksnummer, orgnummerDto, skjæringstidspunkt);
 
@@ -200,10 +225,11 @@ class ForespørselBehandlingTjenesteImpl implements ForespørselBehandlingTjenes
         });
     }
 
+    @Override
     public void settForespørselTilUtgått(SaksnummerDto fagsakSaksnummer, OrganisasjonsnummerDto orgnummerDto, LocalDate skjæringstidspunkt) {
         var forespørsler = hentÅpneForespørslerForFagsak(fagsakSaksnummer, orgnummerDto, skjæringstidspunkt);
 
-        forespørsler.forEach(this::setterForespørselTilUtgått);
+        forespørsler.forEach(this::settForespørselTilUtgått);
     }
 
     private List<ForespørselEntitet> hentÅpneForespørslerForFagsak(SaksnummerDto fagsakSaksnummer,
@@ -216,8 +242,18 @@ class ForespørselBehandlingTjenesteImpl implements ForespørselBehandlingTjenes
     }
 
     @Override
+    public List<ForespørselEntitet> hentForespørslerForFagsak(SaksnummerDto fagsakSaksnummer,
+                                                              OrganisasjonsnummerDto orgnummerDto,
+                                                              LocalDate skjæringstidspunkt) {
+        return forespørselTjeneste.finnForespørslerForFagsak(fagsakSaksnummer).stream()
+            .filter(f -> orgnummerDto == null || orgnummerDto.orgnr().equals(f.getOrganisasjonsnummer()))
+            .filter(f -> skjæringstidspunkt == null || skjæringstidspunkt.equals(f.getSkjæringstidspunkt()))
+            .toList();
+    }
+
+    @Override
     public void slettForespørsel(SaksnummerDto fagsakSaksnummer, OrganisasjonsnummerDto orgnummerDto, LocalDate skjæringstidspunkt) {
-        var sakerSomSkalSlettes = forespørselTjeneste.finnForespørslerForSak(fagsakSaksnummer).stream()
+        var sakerSomSkalSlettes = forespørselTjeneste.finnForespørslerForFagsak(fagsakSaksnummer).stream()
             .filter(f -> skjæringstidspunkt == null || f.getSkjæringstidspunkt().equals(skjæringstidspunkt))
             .filter(f -> orgnummerDto == null || f.getOrganisasjonsnummer().equals(orgnummerDto.orgnr()))
             .filter(f -> f.getStatus().equals(ForespørselStatus.UNDER_BEHANDLING))

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTjeneste.java
@@ -70,7 +70,7 @@ public class ForespørselTjeneste {
         return forespørselRepository.hentForespørsel(forespørselUuid);
     }
 
-    public List<ForespørselEntitet> finnForespørslerForSak(SaksnummerDto fagsakSaksnummer) {
+    public List<ForespørselEntitet> finnForespørslerForFagsak(SaksnummerDto fagsakSaksnummer) {
         return forespørselRepository.hentForespørsler(fagsakSaksnummer);
     }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTask.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTask.java
@@ -61,4 +61,18 @@ public class OpprettForespørselTask implements ProsessTaskHandler {
 
         forespørselBehandlingTjeneste.opprettForespørsel(ytelsetype, aktørId, fagsakSaksnummer, organisasjonsnummer, skjæringstidspunkt);
     }
+
+    public static ProsessTaskData lagTaskData(Ytelsetype ytelsetype,
+                                              AktørIdEntitet aktørId,
+                                              SaksnummerDto fagsakSaksnummer,
+                                              OrganisasjonsnummerDto organisasjon,
+                                              LocalDate skjæringstidspunkt) {
+        var taskdata = ProsessTaskData.forProsessTask(OpprettForespørselTask.class);
+        taskdata.setProperty(YTELSETYPE, ytelsetype.name());
+        taskdata.setProperty(AKTØR_ID, aktørId.getAktørId());
+        taskdata.setProperty(FAGSAK_SAKSNUMMER, fagsakSaksnummer.saksnr());
+        taskdata.setProperty(ORGNR, organisasjon.orgnr());
+        taskdata.setProperty(STP, skjæringstidspunkt.toString());
+        return taskdata;
+    }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTask.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTask.java
@@ -1,0 +1,63 @@
+package no.nav.familie.inntektsmelding.forespørsel.tjenester.task;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import jakarta.inject.Inject;
+
+import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
+import no.nav.familie.inntektsmelding.koder.ForespørselStatus;
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
+import no.nav.familie.inntektsmelding.typer.dto.SaksnummerDto;
+import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
+
+@ApplicationScoped
+@ProsessTask(value = "forespørsel.opprett")
+public class OpprettForespørselTask implements ProsessTaskHandler {
+    private static final Logger log = LoggerFactory.getLogger(OpprettForespørselTask.class);
+
+    public static final String YTELSETYPE = "ytelsetype";
+    public static final String AKTØR_ID = "aktørId";
+    public static final String FAGSAK_SAKSNUMMER = "fagsakSaksnummer";
+    public static final String ORGNR = "orgnr";
+    public static final String STP = "skjæringstidspunkt";
+
+    private ForespørselBehandlingTjeneste forespørselBehandlingTjeneste;
+
+    @Inject
+    public OpprettForespørselTask(ForespørselBehandlingTjeneste forespørselBehandlingTjeneste) {
+        this.forespørselBehandlingTjeneste = forespørselBehandlingTjeneste;
+    }
+
+    OpprettForespørselTask() {
+        // CDI
+    }
+
+    @Override
+    public void doTask(ProsessTaskData prosessTaskData) {
+        Ytelsetype ytelsetype = Ytelsetype.valueOf(prosessTaskData.getPropertyValue(YTELSETYPE));
+        AktørIdEntitet aktørId = new AktørIdEntitet(prosessTaskData.getPropertyValue(AKTØR_ID));
+        SaksnummerDto fagsakSaksnummer = new SaksnummerDto(prosessTaskData.getPropertyValue(FAGSAK_SAKSNUMMER));
+        OrganisasjonsnummerDto organisasjonsnummer = new OrganisasjonsnummerDto(prosessTaskData.getPropertyValue(ORGNR));
+        LocalDate skjæringstidspunkt = LocalDate.parse(prosessTaskData.getPropertyValue(STP));
+
+        List<ForespørselEntitet> eksisterendeForespørsler = forespørselBehandlingTjeneste.hentForespørslerForFagsak(fagsakSaksnummer, organisasjonsnummer, skjæringstidspunkt);
+        if (eksisterendeForespørsler.stream().anyMatch(eksisterende -> !eksisterende.getStatus().equals(ForespørselStatus.UTGÅTT))) {
+            log.info("Forespørsel finnes allerede, orgnr: {}, stp: {}, saksnr: {}, ytelse: {}",
+                organisasjonsnummer.orgnr(), skjæringstidspunkt, fagsakSaksnummer.saksnr(), ytelsetype);
+            return;
+        }
+
+        forespørselBehandlingTjeneste.opprettForespørsel(ytelsetype, aktørId, fagsakSaksnummer, organisasjonsnummer, skjæringstidspunkt);
+    }
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTask.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTask.java
@@ -27,10 +27,10 @@ public class OpprettForespørselTask implements ProsessTaskHandler {
     private static final Logger log = LoggerFactory.getLogger(OpprettForespørselTask.class);
 
     public static final String YTELSETYPE = "ytelsetype";
-    public static final String AKTØR_ID = "aktørId";
+    public static final String AKTØR_ID = "aktoerId";
     public static final String FAGSAK_SAKSNUMMER = "fagsakSaksnummer";
     public static final String ORGNR = "orgnr";
-    public static final String STP = "skjæringstidspunkt";
+    public static final String STP = "skjaeringstidspunkt";
 
     private ForespørselBehandlingTjeneste forespørselBehandlingTjeneste;
 

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTask.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTask.java
@@ -22,8 +22,9 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
 
 @ApplicationScoped
-@ProsessTask(value = "forespørsel.opprett")
+@ProsessTask(value = OpprettForespørselTask.TASKTYPE)
 public class OpprettForespørselTask implements ProsessTaskHandler {
+    public static final String TASKTYPE = "forespørsel.opprett";
     private static final Logger log = LoggerFactory.getLogger(OpprettForespørselTask.class);
 
     public static final String YTELSETYPE = "ytelsetype";

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/SettForespørselTilUtgåttTask.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/SettForespørselTilUtgåttTask.java
@@ -1,0 +1,56 @@
+package no.nav.familie.inntektsmelding.forespørsel.tjenester.task;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import jakarta.inject.Inject;
+
+import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
+import no.nav.familie.inntektsmelding.koder.ForespørselStatus;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
+
+@ApplicationScoped
+@ProsessTask(value = "forespørsel.utgått")
+public class SettForespørselTilUtgåttTask implements ProsessTaskHandler {
+    private static final Logger log = LoggerFactory.getLogger(SettForespørselTilUtgåttTask.class);
+
+    public static final String FORESPØRSEL_UUID = "forespørselUuid";
+
+    private ForespørselBehandlingTjeneste forespørselBehandlingTjeneste;
+
+    @Inject
+    public SettForespørselTilUtgåttTask(ForespørselBehandlingTjeneste forespørselBehandlingTjeneste) {
+        this.forespørselBehandlingTjeneste = forespørselBehandlingTjeneste;
+    }
+
+    SettForespørselTilUtgåttTask() {
+        // CDI
+    }
+
+    @Override
+    public void doTask(ProsessTaskData prosessTaskData) {
+        String forespørselUuid = prosessTaskData.getPropertyValue(FORESPØRSEL_UUID);
+        Optional<ForespørselEntitet> opt = forespørselBehandlingTjeneste.hentForespørsel(UUID.fromString(forespørselUuid));
+
+        if (opt.isEmpty()) {
+            log.warn("Fant ikke forespørsel med uuid {}", forespørselUuid);
+            return;
+        }
+
+        ForespørselEntitet forespørsel = opt.get();
+        if (forespørsel.getStatus() != ForespørselStatus.UNDER_BEHANDLING) {
+            log.info("Forespørsel med uuid {} kan ikke settes til utgått, status er {}", forespørselUuid, forespørsel.getStatus());
+            return;
+        }
+
+        forespørselBehandlingTjeneste.settForespørselTilUtgått(forespørsel);
+    }
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/SettForespørselTilUtgåttTask.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/SettForespørselTilUtgåttTask.java
@@ -18,8 +18,9 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
 
 @ApplicationScoped
-@ProsessTask(value = "forespørsel.utgått")
+@ProsessTask(value = SettForespørselTilUtgåttTask.TASKTYPE)
 public class SettForespørselTilUtgåttTask implements ProsessTaskHandler {
+    public static final String TASKTYPE = "forespørsel.utgått";
     private static final Logger log = LoggerFactory.getLogger(SettForespørselTilUtgåttTask.class);
 
     public static final String FORESPØRSEL_UUID = "forespoerselUuid";

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/SettForespørselTilUtgåttTask.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/SettForespørselTilUtgåttTask.java
@@ -22,7 +22,7 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
 public class SettForespørselTilUtgåttTask implements ProsessTaskHandler {
     private static final Logger log = LoggerFactory.getLogger(SettForespørselTilUtgåttTask.class);
 
-    public static final String FORESPØRSEL_UUID = "forespørselUuid";
+    public static final String FORESPØRSEL_UUID = "forespoerselUuid";
 
     private ForespørselBehandlingTjeneste forespørselBehandlingTjeneste;
 

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImplTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImplTest.java
@@ -27,6 +27,7 @@ import no.nav.familie.inntektsmelding.typer.dto.ForespørselResultat;
 import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
 import no.nav.familie.inntektsmelding.typer.dto.SaksnummerDto;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 import no.nav.vedtak.felles.testutilities.db.EntityManagerAwareTest;
 
 @ExtendWith(JpaTestcontainerExtension.class)
@@ -46,13 +47,15 @@ public class ForespørselBehandlingTjenesteImplTest extends EntityManagerAwareTe
     private final PersonTjeneste personTjeneste = Mockito.mock(PersonTjeneste.class);
     private ForespørselRepository forespørselRepository;
     private ForespørselBehandlingTjeneste forespørselBehandlingTjeneste;
+    private final ProsessTaskTjeneste prosessTaskTjeneste = Mockito.mock(ProsessTaskTjeneste.class);
 
     @BeforeEach
     public void setUp() {
         this.forespørselRepository = new ForespørselRepository(getEntityManager());
         this.forespørselBehandlingTjeneste = new ForespørselBehandlingTjenesteImpl(new ForespørselTjeneste(forespørselRepository),
             arbeidsgiverNotifikasjon,
-            personTjeneste);
+            personTjeneste,
+            prosessTaskTjeneste);
     }
 
     @Test

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImplTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImplTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
@@ -13,10 +14,13 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import no.nav.familie.inntektsmelding.database.JpaTestcontainerExtension;
 import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselRepository;
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.task.OpprettForespørselTask;
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.task.SettForespørselTilUtgåttTask;
 import no.nav.familie.inntektsmelding.integrasjoner.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjon;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonInfo;
@@ -27,6 +31,7 @@ import no.nav.familie.inntektsmelding.typer.dto.ForespørselResultat;
 import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
 import no.nav.familie.inntektsmelding.typer.dto.SaksnummerDto;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskGruppe;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 import no.nav.vedtak.felles.testutilities.db.EntityManagerAwareTest;
 
@@ -190,11 +195,17 @@ public class ForespørselBehandlingTjenesteImplTest extends EntityManagerAwareTe
         }};
         forespørselBehandlingTjeneste.oppdaterForespørsler(YTELSETYPE, new AktørIdEntitet(AKTØR_ID), orgPerStp, new SaksnummerDto(SAKSNUMMMER));
 
-        clearHibernateCache();
-
-        var forespørslerForFagsak = forespørselRepository.hentForespørsler(new SaksnummerDto(SAKSNUMMMER));
-        assertThat(forespørslerForFagsak.size()).isEqualTo(1);
-        assertThat(forespørslerForFagsak.getFirst().getStatus()).isEqualTo(ForespørselStatus.UNDER_BEHANDLING);
+        var captor = ArgumentCaptor.forClass(ProsessTaskGruppe.class);
+        verify(prosessTaskTjeneste).lagre(captor.capture());
+        var taskGruppe = captor.getValue();
+        assertThat(taskGruppe.getTasks().size()).isEqualTo(1);
+        var taskdata = taskGruppe.getTasks().getFirst().task();
+        assertThat(taskdata.getTaskType()).isEqualTo(OpprettForespørselTask.TASKTYPE);
+        assertThat(taskdata.getPropertyValue(OpprettForespørselTask.YTELSETYPE)).isEqualTo(YTELSETYPE.toString());
+        assertThat(taskdata.getPropertyValue(OpprettForespørselTask.FAGSAK_SAKSNUMMER)).isEqualTo(SAKSNUMMMER);
+        assertThat(taskdata.getPropertyValue(OpprettForespørselTask.AKTØR_ID)).isEqualTo(AKTØR_ID);
+        assertThat(taskdata.getPropertyValue(OpprettForespørselTask.ORGNR)).isEqualTo(BRREG_ORGNUMMER);
+        assertThat(taskdata.getPropertyValue(OpprettForespørselTask.STP)).isEqualTo(SKJÆRINGSTIDSPUNKT.toString());
     }
 
     @Test
@@ -207,11 +218,7 @@ public class ForespørselBehandlingTjenesteImplTest extends EntityManagerAwareTe
         }};
         forespørselBehandlingTjeneste.oppdaterForespørsler(YTELSETYPE, new AktørIdEntitet(AKTØR_ID), orgPerStp, new SaksnummerDto(SAKSNUMMMER));
 
-        clearHibernateCache();
-
-        var forespørslerForFagsak = forespørselRepository.hentForespørsler(new SaksnummerDto(SAKSNUMMMER));
-        assertThat(forespørslerForFagsak.size()).isEqualTo(1);
-        assertThat(forespørslerForFagsak.getFirst().getStatus()).isEqualTo(ForespørselStatus.UNDER_BEHANDLING);
+        verifyNoInteractions(prosessTaskTjeneste);
     }
 
     @Test
@@ -227,12 +234,12 @@ public class ForespørselBehandlingTjenesteImplTest extends EntityManagerAwareTe
         }};
         forespørselBehandlingTjeneste.oppdaterForespørsler(YTELSETYPE, new AktørIdEntitet(AKTØR_ID), orgPerStp, new SaksnummerDto(SAKSNUMMMER));
 
-        clearHibernateCache();
-
-        var forespørslerForFagsak = forespørselRepository.hentForespørsler(new SaksnummerDto(SAKSNUMMMER));
-        assertThat(forespørslerForFagsak.size()).isEqualTo(2);
-        assertThat(forespørslerForFagsak.get(0).getStatus()).isEqualTo(ForespørselStatus.UNDER_BEHANDLING);
-        assertThat(forespørslerForFagsak.get(1).getStatus()).isEqualTo(ForespørselStatus.UNDER_BEHANDLING);
+        var captor = ArgumentCaptor.forClass(ProsessTaskGruppe.class);
+        verify(prosessTaskTjeneste).lagre(captor.capture());
+        var taskGruppe = captor.getValue();
+        assertThat(taskGruppe.getTasks().size()).isEqualTo(1);
+        var taskdata1 = taskGruppe.getTasks().getFirst().task();
+        assertThat(taskdata1.getTaskType()).isEqualTo(OpprettForespørselTask.TASKTYPE);
     }
 
     @Test
@@ -249,14 +256,15 @@ public class ForespørselBehandlingTjenesteImplTest extends EntityManagerAwareTe
         mockInfoForOpprettelse(AKTØR_ID, YTELSETYPE, BRREG_ORGNUMMER, SAK_ID_2, OPPGAVE_ID_2);
         forespørselBehandlingTjeneste.oppdaterForespørsler(YTELSETYPE, new AktørIdEntitet(AKTØR_ID), orgPerStp, new SaksnummerDto(SAKSNUMMMER));
 
-        clearHibernateCache();
-
-        var forespørslerForFagsak = forespørselRepository.hentForespørsler(new SaksnummerDto(SAKSNUMMMER));
-        var utgåtteForespørsler = forespørslerForFagsak.stream().filter(f -> f.getStatus() == ForespørselStatus.UTGÅTT).toList();
-        var forespørslerUnderBehandling = forespørslerForFagsak.stream().filter(f -> f.getStatus() == ForespørselStatus.UNDER_BEHANDLING).toList();
-        assertThat(forespørslerForFagsak.size()).isEqualTo(2);
-        assertThat(forespørslerUnderBehandling.size()).isEqualTo(1);
-        assertThat(utgåtteForespørsler.size()).isEqualTo(1);
+        var captor = ArgumentCaptor.forClass(ProsessTaskGruppe.class);
+        verify(prosessTaskTjeneste).lagre(captor.capture());
+        var taskGruppe = captor.getValue();
+        assertThat(taskGruppe.getTasks().size()).isEqualTo(2);
+        var taskdata1 = taskGruppe.getTasks().get(0).task();
+        assertThat(taskdata1.getTaskType()).isEqualTo(OpprettForespørselTask.TASKTYPE);
+        var taskdata2 = taskGruppe.getTasks().get(1).task();
+        assertThat(taskdata2.getTaskType()).isEqualTo(SettForespørselTilUtgåttTask.TASKTYPE);
+        assertThat(taskdata2.getPropertyValue(SettForespørselTilUtgåttTask.FORESPØRSEL_UUID)).isEqualTo(forespørselUuid.toString());
     }
 
     @Test

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTaskTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTaskTest.java
@@ -1,0 +1,64 @@
+package no.nav.familie.inntektsmelding.forespørsel.tjenester.task;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
+import no.nav.familie.inntektsmelding.typer.dto.SaksnummerDto;
+import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+
+class OpprettForespørselTaskTest {
+
+    private final Ytelsetype ytelsetype = Ytelsetype.PLEIEPENGER_SYKT_BARN;
+    private final AktørIdEntitet aktørId = new AktørIdEntitet("1111111111111");
+    private final SaksnummerDto fagsakSaksnummer = new SaksnummerDto("456");
+    private final OrganisasjonsnummerDto organisasjon = new OrganisasjonsnummerDto("789");
+    private final LocalDate skjæringstidspunkt = LocalDate.now();
+
+    private final ForespørselBehandlingTjeneste forespørselBehandlingTjeneste = Mockito.mock(ForespørselBehandlingTjeneste.class);
+
+    @Test
+    void skal_opprette_forespørsel_dersom_det_ikke_eksisterer_en_for_stp() {
+        var task = new OpprettForespørselTask(forespørselBehandlingTjeneste);
+        var taskdata = ProsessTaskData.forProsessTask(OpprettForespørselTask.class);
+        taskdata.setProperty(OpprettForespørselTask.YTELSETYPE, ytelsetype.name());
+        taskdata.setProperty(OpprettForespørselTask.AKTØR_ID, aktørId.getAktørId());
+        taskdata.setProperty(OpprettForespørselTask.FAGSAK_SAKSNUMMER, fagsakSaksnummer.saksnr());
+        taskdata.setProperty(OpprettForespørselTask.ORGNR, organisasjon.orgnr());
+        taskdata.setProperty(OpprettForespørselTask.STP, skjæringstidspunkt.toString());
+
+        task.doTask(taskdata);
+
+        verify(forespørselBehandlingTjeneste).opprettForespørsel(ytelsetype, aktørId, fagsakSaksnummer, organisasjon, skjæringstidspunkt);
+    }
+
+    @Test
+    void skal_ikke_opprette_ny_forespørsel_dersom_det_eksisterer_en_for_samme_stp() {
+        var task = new OpprettForespørselTask(forespørselBehandlingTjeneste);
+        var taskdata = ProsessTaskData.forProsessTask(OpprettForespørselTask.class);
+        taskdata.setProperty(OpprettForespørselTask.YTELSETYPE, ytelsetype.name());
+        taskdata.setProperty(OpprettForespørselTask.AKTØR_ID, aktørId.getAktørId());
+        taskdata.setProperty(OpprettForespørselTask.FAGSAK_SAKSNUMMER, fagsakSaksnummer.saksnr());
+        taskdata.setProperty(OpprettForespørselTask.ORGNR, organisasjon.orgnr());
+        taskdata.setProperty(OpprettForespørselTask.STP, skjæringstidspunkt.toString());
+
+        when(forespørselBehandlingTjeneste.hentForespørslerForFagsak(fagsakSaksnummer, organisasjon, skjæringstidspunkt))
+            .thenReturn(List.of(new ForespørselEntitet(organisasjon.orgnr(), skjæringstidspunkt, aktørId, ytelsetype, fagsakSaksnummer.saksnr())));
+
+        task.doTask(taskdata);
+
+        verify(forespørselBehandlingTjeneste, times(0)).opprettForespørsel(any(), any(), any(), any(), any());
+    }
+}

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/SettForespørselTilUtgåttTaskTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/SettForespørselTilUtgåttTaskTest.java
@@ -1,0 +1,55 @@
+package no.nav.familie.inntektsmelding.forespørsel.tjenester.task;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
+import no.nav.familie.inntektsmelding.koder.ForespørselStatus;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+
+class SettForespørselTilUtgåttTaskTest {
+
+    private final UUID forespørselUuid = UUID.randomUUID();
+    private final ForespørselEntitet entitet = new ForespørselEntitet();
+
+    private final ForespørselBehandlingTjeneste forespørselBehandlingTjeneste = Mockito.mock(ForespørselBehandlingTjeneste.class);
+
+    @Test
+    void skal_sette_forespørsel_til_utgått() {
+        var task = new SettForespørselTilUtgåttTask(forespørselBehandlingTjeneste);
+        var taskdata = ProsessTaskData.forProsessTask(SettForespørselTilUtgåttTask.class);
+        taskdata.setProperty(SettForespørselTilUtgåttTask.FORESPØRSEL_UUID, forespørselUuid.toString());
+
+        entitet.setStatus(ForespørselStatus.UNDER_BEHANDLING);
+        when(forespørselBehandlingTjeneste.hentForespørsel(forespørselUuid))
+            .thenReturn(Optional.of(entitet));
+
+        task.doTask(taskdata);
+
+        verify(forespørselBehandlingTjeneste).settForespørselTilUtgått(entitet);
+    }
+
+    @Test
+    void skal_ikke_sette_ferdig_forespørsel_til_utgått() {
+        var task = new SettForespørselTilUtgåttTask(forespørselBehandlingTjeneste);
+        var taskdata = ProsessTaskData.forProsessTask(SettForespørselTilUtgåttTask.class);
+        taskdata.setProperty(SettForespørselTilUtgåttTask.FORESPØRSEL_UUID, forespørselUuid.toString());
+
+        entitet.setStatus(ForespørselStatus.FERDIG);
+        when(forespørselBehandlingTjeneste.hentForespørsel(forespørselUuid))
+            .thenReturn(Optional.of(entitet));
+
+        task.doTask(taskdata);
+
+        verify(forespørselBehandlingTjeneste, times(0)).settForespørselTilUtgått(any(ForespørselEntitet.class));
+    }
+}


### PR DESCRIPTION
Problemet vi forsøker å løse her er at vi ikke har transaksjonshåndtering mot arbeidsgiverportalen, så hvis noe feiler og db-transaksjonen rulles tilbake så blir det likevel liggende der. Dette er et problem for oppdater-tjenesten fordi den håndterer flere forespørsler i samme transaksjon. 
Å bruke prosesstasks for hver enkelt forespørsel er bare en mulig løsning. En annen mulighet er å starte egne transaksjoner per forespørsel. En fordel med prosesstasks er at vi får mulighet for retry. En (mulig) ulempe er at k9-sak/fp-sak ikke får vite at det har feilet.