### PR TITLE
POFIM-96 Opprett forespørsel

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselEntitet.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselEntitet.java
@@ -162,5 +162,4 @@ public class ForespørselEntitet {
         }
         return "*".repeat(length - 4) + id.substring(length - 4);
     }
-
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselRepository.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselRepository.java
@@ -10,6 +10,8 @@ import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 
+import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -136,12 +138,16 @@ public class ForespørselRepository {
 
     public Optional<ForespørselEntitet> finnÅpenForespørsel(AktørIdEntitet aktørId,
                                                             Ytelsetype ytelsetype,
-                                                            String arbeidsgiverIdent,
-                                                            LocalDate startdato) {
+                                                            OrganisasjonsnummerDto organisasjonsnummer,
+                                                            LocalDate startdato,
+                                                            SaksnummerDto fagsakSaksnummer) {
+        var arbeidsgiverIdent = organisasjonsnummer.orgnr();
         var query = entityManager.createQuery("FROM ForespørselEntitet where status='UNDER_BEHANDLING' " + "and aktørId = :brukerAktørId "
-                    + "and organisasjonsnummer = :arbeidsgiverIdent " + "and skjæringstidspunkt = :skjæringstidspunkt " + "and ytelseType = :ytelsetype",
+                    + "and fagsystemSaksnummer = :fagsakNr " +  "and organisasjonsnummer = :arbeidsgiverIdent " + "and skjæringstidspunkt = :skjæringstidspunkt "
+                    + "and ytelseType = :ytelsetype",
                 ForespørselEntitet.class)
             .setParameter("brukerAktørId", aktørId)
+            .setParameter("fagsakNr", fagsakSaksnummer.saksnr())
             .setParameter("arbeidsgiverIdent", arbeidsgiverIdent)
             .setParameter("skjæringstidspunkt", startdato)
             .setParameter("ytelsetype", ytelsetype);
@@ -151,7 +157,7 @@ public class ForespørselRepository {
             return Optional.empty();
         } else if (resultList.size() > 1) {
             throw new IllegalStateException(
-                "Forventet å finne kun en forespørsel for gitt id arbeidsgiver og startdato" + aktørId + arbeidsgiverIdent + startdato);
+                "Forventet å finne kun en forespørsel for gitt id arbeidsgiver og startdato" + aktørId + organisasjonsnummer + startdato);
         } else {
             return Optional.of(resultList.getFirst());
         }

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImpl.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImpl.java
@@ -61,10 +61,10 @@ class ForespørselBehandlingTjenesteImpl implements ForespørselBehandlingTjenes
                                                              AktørIdEntitet aktørId,
                                                              OrganisasjonsnummerDto organisasjonsnummer,
                                                              SaksnummerDto fagsakSaksnummer) {
-        var åpenForespørsel = forespørselTjeneste.finnÅpenForespørsel(skjæringstidspunkt, ytelsetype, aktørId, organisasjonsnummer);
+        var åpenForespørsel = forespørselTjeneste.finnÅpenForespørsel(skjæringstidspunkt, ytelsetype, aktørId, organisasjonsnummer, fagsakSaksnummer);
 
         if (åpenForespørsel.isPresent()) {
-            LOG.info("Finnes allerede forespørsel for aktør {} på startdato {} + på ytelse {}", aktørId, skjæringstidspunkt, ytelsetype);
+            LOG.info("Finnes allerede forespørsel for aktør {} med orgnummer {} og saksnr {} på startdato {} på ytelse {}", aktørId, organisasjonsnummer, fagsakSaksnummer, skjæringstidspunkt, ytelsetype);
             return ForespørselResultat.IKKE_OPPRETTET_FINNES_ALLEREDE_ÅPEN;
         }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTjeneste.java
@@ -58,8 +58,9 @@ public class ForespørselTjeneste {
     public Optional<ForespørselEntitet> finnÅpenForespørsel(LocalDate skjæringstidspunkt,
                                                             Ytelsetype ytelseType,
                                                             AktørIdEntitet brukerAktørId,
-                                                            OrganisasjonsnummerDto orgnr) {
-        return forespørselRepository.finnÅpenForespørsel(brukerAktørId, ytelseType, orgnr.orgnr(), skjæringstidspunkt);
+                                                            OrganisasjonsnummerDto orgnr,
+                                                            SaksnummerDto fagsakSaksnummer) {
+        return forespørselRepository.finnÅpenForespørsel(brukerAktørId, ytelseType, orgnr, skjæringstidspunkt, fagsakSaksnummer);
     }
 
     public List<ForespørselEntitet> finnÅpneForespørslerForFagsak(SaksnummerDto fagsakSaksnummer) {

--- a/src/main/java/no/nav/familie/inntektsmelding/typer/dto/OrganisasjonsnummerDto.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/typer/dto/OrganisasjonsnummerDto.java
@@ -30,6 +30,6 @@ public record OrganisasjonsnummerDto(
 
     @Override
     public String toString() {
-        return "Organisasjonsnummer[" + "orgnr=" + orgnr.substring(0, Math.min(orgnr.length(), 3)) + "...]";
+        return "Organisasjonsnummer[" + "orgnr=" + "*".repeat(orgnr.length() - 4) + orgnr.substring(orgnr.length() - 4) + "]";
     }
 }


### PR DESCRIPTION
Legger til saksnummer når vi søker etter åpne forespørsler for å hindre at fp-autotest feiler på at det finnes flere enn 1 åpen forespørsel. Fikser også at vi ikke maskerer orgnummer noen steder, og at vi maskerer på lik måte på OrganisasjonsnummerDto og ForespørselEntitet.