### PR TITLE
POFIM-131 Oppretter kun ny forespørsel dersom det ikke finnes en med …

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselRepository.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselRepository.java
@@ -144,7 +144,7 @@ public class ForespørselRepository {
             return Optional.empty();
         } else if (resultList.size() > 1) {
             throw new IllegalStateException(
-                "Forventet å finne kun en forespørsel for gitt sak {}, arbeidsgiver {}, skjæringstidspunkt {} og første uttaksdato" + aktørId + organisasjonsnummer + stp + førsteUttaksdato);
+                "Forventet å finne kun en forespørsel for gitt sak {}, orgnr {}, skjæringstidspunkt {} og første uttaksdato" + fagsakSaksnummer + organisasjonsnummer + stp + førsteUttaksdato);
         } else {
             return Optional.of(resultList.getFirst());
         }

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImpl.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImpl.java
@@ -62,11 +62,11 @@ class ForespørselBehandlingTjenesteImpl implements ForespørselBehandlingTjenes
                                                              OrganisasjonsnummerDto organisasjonsnummer,
                                                              SaksnummerDto fagsakSaksnummer,
                                                              LocalDate førsteUttaksdato) {
-        var åpenForespørsel = forespørselTjeneste.finnÅpenForespørsel(skjæringstidspunkt, ytelsetype, aktørId, organisasjonsnummer, fagsakSaksnummer);
+        var finnesForespørsel = forespørselTjeneste.finnGjeldendeForespørsel(skjæringstidspunkt, ytelsetype, aktørId, organisasjonsnummer, fagsakSaksnummer, førsteUttaksdato);
 
-        if (åpenForespørsel.isPresent()) {
-            LOG.info("Finnes allerede forespørsel for aktør {} med orgnummer {} og saksnr {} på skjæringstidspunkt {} på ytelse {}", aktørId, organisasjonsnummer, fagsakSaksnummer, skjæringstidspunkt, ytelsetype);
-            return ForespørselResultat.IKKE_OPPRETTET_FINNES_ALLEREDE_ÅPEN;
+        if (finnesForespørsel.isPresent()) {
+            LOG.info("Finnes allerede forespørsel for saksnummer: {} med orgnummer: {} med skjæringstidspunkt: {} og første uttaksdato: {}", fagsakSaksnummer, organisasjonsnummer, skjæringstidspunkt, førsteUttaksdato);
+            return ForespørselResultat.IKKE_OPPRETTET_FINNES_ALLEREDE;
         }
 
         opprettForespørsel(ytelsetype, aktørId, fagsakSaksnummer, organisasjonsnummer, skjæringstidspunkt, førsteUttaksdato);

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTjeneste.java
@@ -56,12 +56,12 @@ public class ForespørselTjeneste {
         forespørselRepository.settForespørselTilUtgått(arbeidsgiverNotifikasjonSakId);
     }
 
-    public Optional<ForespørselEntitet> finnÅpenForespørsel(LocalDate skjæringstidspunkt,
-                                                            Ytelsetype ytelseType,
-                                                            AktørIdEntitet brukerAktørId,
-                                                            OrganisasjonsnummerDto orgnr,
-                                                            SaksnummerDto fagsakSaksnummer) {
-        return forespørselRepository.finnÅpenForespørsel(brukerAktørId, ytelseType, orgnr, skjæringstidspunkt, fagsakSaksnummer);
+    public Optional<ForespørselEntitet> finnGjeldendeForespørsel(LocalDate skjæringstidspunkt,
+                                                                 Ytelsetype ytelseType,
+                                                                 AktørIdEntitet brukerAktørId,
+                                                                 OrganisasjonsnummerDto orgnr,
+                                                                 SaksnummerDto fagsakSaksnummer, LocalDate førsteUttaksdato) {
+        return forespørselRepository.finnGjeldendeForespørsel(brukerAktørId, ytelseType, orgnr, skjæringstidspunkt, fagsakSaksnummer, førsteUttaksdato);
     }
 
     public List<ForespørselEntitet> finnÅpneForespørslerForFagsak(SaksnummerDto fagsakSaksnummer) {

--- a/src/main/java/no/nav/familie/inntektsmelding/typer/dto/ForespørselResultat.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/typer/dto/ForespørselResultat.java
@@ -2,5 +2,5 @@ package no.nav.familie.inntektsmelding.typer.dto;
 
 public enum ForespørselResultat {
     FORESPØRSEL_OPPRETTET,
-    IKKE_OPPRETTET_FINNES_ALLEREDE_ÅPEN
+    IKKE_OPPRETTET_FINNES_ALLEREDE
 }


### PR DESCRIPTION
…samme stp og første uttaksdato, eller om forespørselen er utgått. Dette for å forhindre unødvendig opprettelse av forespørsler når inntektsmelding allerede er mottatt.