### PR TITLE
k9: Håndtere rekkefølge av taskgrupper med ProsessTaskLifecycleObserver

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImpl.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImpl.java
@@ -135,6 +135,7 @@ class ForespørselBehandlingTjenesteImpl implements ForespørselBehandlingTjenes
             if (!trengerEksisterendeForespørsel && eksisterendeForespørsel.getStatus() == ForespørselStatus.UNDER_BEHANDLING) {
                 var settForespørselTilUtgåttTask = ProsessTaskData.forProsessTask(SettForespørselTilUtgåttTask.class);
                 settForespørselTilUtgåttTask.setProperty(SettForespørselTilUtgåttTask.FORESPØRSEL_UUID, eksisterendeForespørsel.getUuid().toString());
+                settForespørselTilUtgåttTask.setProperty(OpprettForespørselTask.FAGSAK_SAKSNUMMER, fagsakSaksnummer.saksnr());
                 taskGruppe.addNesteParallell(settForespørselTilUtgåttTask);
             }
         });

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/HåndterRekkefølgeAvForespørselTasks.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/HåndterRekkefølgeAvForespørselTasks.java
@@ -1,0 +1,73 @@
+package no.nav.familie.inntektsmelding.forespørsel.tjenester.task;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import jakarta.inject.Inject;
+
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskGruppe;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskLifecycleObserver;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskStatus;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskVeto;
+import no.nav.vedtak.felles.prosesstask.impl.ProsessTaskRepository;
+
+@ApplicationScoped
+public class HåndterRekkefølgeAvForespørselTasks implements ProsessTaskLifecycleObserver {
+
+    private static final Logger log = LoggerFactory.getLogger(HåndterRekkefølgeAvForespørselTasks.class);
+
+    private ProsessTaskRepository prosessTaskRepository;
+
+    HåndterRekkefølgeAvForespørselTasks() {
+        //CDI
+    }
+
+    @Inject
+    public HåndterRekkefølgeAvForespørselTasks(ProsessTaskRepository prosessTaskRepository) {
+        this.prosessTaskRepository = prosessTaskRepository;
+    }
+
+    @Override
+    public ProsessTaskVeto vetoKjøring(ProsessTaskData prosessTaskData) {
+
+        if (prosessTaskData.getTaskType().equals(OpprettForespørselTask.TASKTYPE)) {
+            String fagsakSaksnummer = prosessTaskData.getPropertyValue(OpprettForespørselTask.FAGSAK_SAKSNUMMER);
+
+            if (fagsakSaksnummer == null || fagsakSaksnummer.isBlank()) {
+                throw new IllegalArgumentException("Task av type " + OpprettForespørselTask.TASKTYPE + " mangler " + OpprettForespørselTask.FAGSAK_SAKSNUMMER);
+            }
+
+            //TODO bytt til en mer spesifikk query når vi er over på k9-prosesstask
+            Optional<ProsessTaskData> blokkerendeTask = prosessTaskRepository.finnAlle(List.of(ProsessTaskStatus.KLAR))
+                .stream()
+                .filter(task -> List.of(OpprettForespørselTask.TASKTYPE, SettForespørselTilUtgåttTask.TASKTYPE).contains(task.getTaskType()))
+                .filter(task -> Objects.equals(task.getPropertyValue(OpprettForespørselTask.FAGSAK_SAKSNUMMER), fagsakSaksnummer))
+                .filter(task -> !Objects.equals(task.getGruppe(), prosessTaskData.getGruppe()))
+                .filter(task -> task.getOpprettetTid().isBefore(prosessTaskData.getOpprettetTid()))
+                .max(Comparator.comparing(ProsessTaskData::getOpprettetTid));
+
+            if (blokkerendeTask.isPresent()) {
+                log.info("Vetoer kjøring av prosesstask[{}] av type[{}] for fagsak [{}], er blokkert av prosesstask[{}] for samme fagsak.",
+                    prosessTaskData.getId(), prosessTaskData.getTaskType(), fagsakSaksnummer, blokkerendeTask.get().getId());
+
+                return new ProsessTaskVeto(true, prosessTaskData.getId(), blokkerendeTask.get().getId(),
+                    "Må vente på annen task for samme fagsak som ble opprettet før denne.");
+            }
+        }
+
+        return new ProsessTaskVeto(false, prosessTaskData.getId());
+    }
+
+    @Override
+    public void opprettetProsessTaskGruppe(ProsessTaskGruppe sammensattTask) {
+
+    }
+}

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTaskTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTaskTest.java
@@ -18,7 +18,6 @@ import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
 import no.nav.familie.inntektsmelding.typer.dto.SaksnummerDto;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
-import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
 class OpprettForespørselTaskTest {
 
@@ -29,11 +28,10 @@ class OpprettForespørselTaskTest {
     private final LocalDate skjæringstidspunkt = LocalDate.now();
 
     private final ForespørselBehandlingTjeneste forespørselBehandlingTjeneste = Mockito.mock(ForespørselBehandlingTjeneste.class);
-    private final ProsessTaskTjeneste prosessTaskTjeneste = Mockito.mock(ProsessTaskTjeneste.class);
 
     @Test
     void skal_opprette_forespørsel_dersom_det_ikke_eksisterer_en_for_stp() {
-        var task = new OpprettForespørselTask(forespørselBehandlingTjeneste, prosessTaskTjeneste);
+        var task = new OpprettForespørselTask(forespørselBehandlingTjeneste);
         var taskdata = ProsessTaskData.forProsessTask(OpprettForespørselTask.class);
         taskdata.setProperty(OpprettForespørselTask.YTELSETYPE, ytelsetype.name());
         taskdata.setProperty(OpprettForespørselTask.AKTØR_ID, aktørId.getAktørId());
@@ -49,7 +47,7 @@ class OpprettForespørselTaskTest {
 
     @Test
     void skal_ikke_opprette_ny_forespørsel_dersom_det_eksisterer_en_for_samme_stp() {
-        var task = new OpprettForespørselTask(forespørselBehandlingTjeneste, prosessTaskTjeneste);
+        var task = new OpprettForespørselTask(forespørselBehandlingTjeneste);
         var taskdata = ProsessTaskData.forProsessTask(OpprettForespørselTask.class);
         taskdata.setProperty(OpprettForespørselTask.YTELSETYPE, ytelsetype.name());
         taskdata.setProperty(OpprettForespørselTask.AKTØR_ID, aktørId.getAktørId());


### PR DESCRIPTION
Inspirert av https://github.com/navikt/k9-sak/blob/master/behandlingslager/domene/src/main/java/no/nav/k9/sak/behandlingslager/fagsak/H%C3%A5ndterRekkef%C3%B8lgeAvFagsakProsessTaskGrupper.java