### PR TITLE
POFIM-81 Endring for endepunkt /sett-til-utgatt

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselRepository.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselRepository.java
@@ -155,4 +155,12 @@ public class ForespørselRepository {
             .setParameter("status", ForespørselStatus.UNDER_BEHANDLING);
         return query.getResultList();
     }
+
+    public List<ForespørselEntitet> hentGjeldendeForespørsler(SaksnummerDto fagsakSaksnummer) {
+        var query = entityManager.createQuery("FROM ForespørselEntitet where status in (:statuser) " + "and fagsystemSaksnummer=:saksnummer",
+                ForespørselEntitet.class)
+            .setParameter("saksnummer", fagsakSaksnummer.saksnr())
+            .setParameter("statuser", Set.of(ForespørselStatus.UNDER_BEHANDLING, ForespørselStatus.FERDIG));
+        return query.getResultList();
+    }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/rest/ForespørselRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/rest/ForespørselRest.java
@@ -109,11 +109,11 @@ public class ForespørselRest {
     @Path("/sett-til-utgatt")
     @Tilgangskontrollert
     public Response settForespørselTilUtgått(@Valid @NotNull LukkForespørselRequest request) {
-        LOG.info("Setter forespørsel for fagsakSaksnummer {} til utgått", request.fagsakSaksnummer());
+        LOG.info("Setter forespørsler for fagsakSaksnummer {} til utgått", request.fagsakSaksnummer());
 
         sjekkErSystemkall();
 
-        forespørselBehandlingTjeneste.settForespørselTilUtgått(request.fagsakSaksnummer(), request.orgnummer(), request.skjæringstidspunkt());
+        forespørselBehandlingTjeneste.settForespørslerTilUtgått(request.fagsakSaksnummer(), request.orgnummer(), request.skjæringstidspunkt());
         return Response.ok().build();
     }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -2,7 +2,6 @@ package no.nav.familie.inntektsmelding.forespørsel.tjenester;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -51,7 +50,7 @@ public interface ForespørselBehandlingTjeneste {
     void slettForespørsel(SaksnummerDto fagsakSaksnummer, OrganisasjonsnummerDto orgnummerDto, LocalDate skjæringstidspunkt);
 
 
-    void settForespørselTilUtgått(SaksnummerDto saksnummerDto, OrganisasjonsnummerDto orgnummer, LocalDate skjæringstidspunkt);
+    void settForespørslerTilUtgått(SaksnummerDto saksnummerDto, OrganisasjonsnummerDto orgnummer, LocalDate skjæringstidspunkt);
 
     void settForespørselTilUtgått(ForespørselEntitet eksisterendeForespørsel, boolean skalOppdatereArbeidsgiverNotifikasjon);
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImpl.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImpl.java
@@ -4,7 +4,6 @@ import java.net.URI;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -172,14 +171,13 @@ class ForespørselBehandlingTjenesteImpl implements ForespørselBehandlingTjenes
 
         arbeidsgiverNotifikasjon.oppdaterSakTilleggsinformasjon(eksisterendeForespørsel.getArbeidsgiverNotifikasjonSakId(),
             ForespørselTekster.lagTilleggsInformasjon(LukkeÅrsak.UTGÅTT));
+        //forespørsel i ftinntektsmelding
         forespørselTjeneste.settForespørselTilUtgått(eksisterendeForespørsel.getArbeidsgiverNotifikasjonSakId());
 
-        var msg = String.format("Setter forespørsel til utgått, orgnr: %s, stp: %s, saksnr: %s, ytelse: %s",
-            eksisterendeForespørsel.getOrganisasjonsnummer(),
+        LOG.info("Setter forespørsel til utgått, orgnr: {}, stp: {}, saksnr: {}, ytelse: {}", eksisterendeForespørsel.getOrganisasjonsnummer(),
             eksisterendeForespørsel.getSkjæringstidspunkt(),
             eksisterendeForespørsel.getFagsystemSaksnummer(),
             eksisterendeForespørsel.getYtelseType());
-        LOG.info(msg);
     }
 
     private boolean innholderRequestEksisterendeForespørsel(List<ForespørselDto> forepørsler,
@@ -242,10 +240,20 @@ class ForespørselBehandlingTjenesteImpl implements ForespørselBehandlingTjenes
     }
 
     @Override
-    public void settForespørselTilUtgått(SaksnummerDto fagsakSaksnummer, OrganisasjonsnummerDto orgnummerDto, LocalDate skjæringstidspunkt) {
-        var forespørsler = hentÅpneForespørslerForFagsak(fagsakSaksnummer, orgnummerDto, skjæringstidspunkt);
+    public void settForespørslerTilUtgått(SaksnummerDto fagsakSaksnummer, OrganisasjonsnummerDto orgnummerDto, LocalDate skjæringstidspunkt) {
+        var forespørsler = hentGjeldendeForespørslerForFagsak(fagsakSaksnummer, orgnummerDto, skjæringstidspunkt);
 
-        forespørsler.forEach(it -> settForespørselTilUtgått(it, true));
+        forespørsler.forEach(forespørselEntitet -> {
+            var skalOppdatereArbgiverportalen = ForespørselStatus.UNDER_BEHANDLING.equals(forespørselEntitet.getStatus());
+            settForespørselTilUtgått(forespørselEntitet, skalOppdatereArbgiverportalen);
+        });
+    }
+
+    private List<ForespørselEntitet> hentGjeldendeForespørslerForFagsak(SaksnummerDto fagsakSaksnummer, OrganisasjonsnummerDto orgnummerDto, LocalDate skjæringstidspunkt) {
+        return forespørselTjeneste.finnGjeldeneForespørslerForFagsak(fagsakSaksnummer).stream()
+            .filter(f -> orgnummerDto == null || orgnummerDto.orgnr().equals(f.getOrganisasjonsnummer()))
+            .filter(f -> skjæringstidspunkt == null || skjæringstidspunkt.equals(f.getSkjæringstidspunkt()))
+            .toList();
     }
 
     private List<ForespørselEntitet> hentÅpneForespørslerForFagsak(SaksnummerDto fagsakSaksnummer,

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImpl.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImpl.java
@@ -250,16 +250,19 @@ class ForespørselBehandlingTjenesteImpl implements ForespørselBehandlingTjenes
     }
 
     private List<ForespørselEntitet> hentGjeldendeForespørslerForFagsak(SaksnummerDto fagsakSaksnummer, OrganisasjonsnummerDto orgnummerDto, LocalDate skjæringstidspunkt) {
-        return forespørselTjeneste.finnGjeldeneForespørslerForFagsak(fagsakSaksnummer).stream()
-            .filter(f -> orgnummerDto == null || orgnummerDto.orgnr().equals(f.getOrganisasjonsnummer()))
-            .filter(f -> skjæringstidspunkt == null || skjæringstidspunkt.equals(f.getSkjæringstidspunkt()))
-            .toList();
+        var gjeldendeForespørsler = forespørselTjeneste.finnGjeldeneForespørslerForFagsak(fagsakSaksnummer);
+        return filtrerForespørsler(gjeldendeForespørsler, orgnummerDto, skjæringstidspunkt);
     }
 
     private List<ForespørselEntitet> hentÅpneForespørslerForFagsak(SaksnummerDto fagsakSaksnummer,
                                                                    OrganisasjonsnummerDto orgnummerDto,
                                                                    LocalDate skjæringstidspunkt) {
-        return forespørselTjeneste.finnÅpneForespørslerForFagsak(fagsakSaksnummer).stream()
+        var åpneForepsørsler = forespørselTjeneste.finnÅpneForespørslerForFagsak(fagsakSaksnummer);
+        return filtrerForespørsler(åpneForepsørsler, orgnummerDto, skjæringstidspunkt);
+    }
+
+    private List<ForespørselEntitet> filtrerForespørsler(List<ForespørselEntitet> forespørsler, OrganisasjonsnummerDto orgnummerDto, LocalDate skjæringstidspunkt) {
+        return forespørsler.stream()
             .filter(f -> orgnummerDto == null || orgnummerDto.orgnr().equals(f.getOrganisasjonsnummer()))
             .filter(f -> skjæringstidspunkt == null || skjæringstidspunkt.equals(f.getSkjæringstidspunkt()))
             .toList();

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTjeneste.java
@@ -76,4 +76,7 @@ public class ForespørselTjeneste {
         return forespørselRepository.hentForespørsler(fagsakSaksnummer);
     }
 
+    public List<ForespørselEntitet> finnGjeldeneForespørslerForFagsak(SaksnummerDto fagsakSaksnummer) {
+        return forespørselRepository.hentGjeldendeForespørsler(fagsakSaksnummer);
+    }
 }

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImplTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImplTest.java
@@ -224,7 +224,7 @@ public class ForespørselBehandlingTjenesteImplTest extends EntityManagerAwareTe
     }
 
     @Test
-    public void skal_sette_alle_forespørspørsler_for_sak_til_utgått() {
+    public void skal_sette_alle_åpne_forespørspørsler_for_sak_til_utgått() {
         var forespørselUuid = forespørselRepository.lagreForespørsel(SKJÆRINGSTIDSPUNKT, YTELSETYPE, AKTØR_ID, BRREG_ORGNUMMER, SAKSNUMMMER,
             FØRSTE_UTTAKSDATO);
         forespørselRepository.oppdaterArbeidsgiverNotifikasjonSakId(forespørselUuid, SAK_ID);
@@ -236,7 +236,7 @@ public class ForespørselBehandlingTjenesteImplTest extends EntityManagerAwareTe
             FØRSTE_UTTAKSDATO);
         forespørselRepository.oppdaterArbeidsgiverNotifikasjonSakId(forespørselUuid2, "2");
 
-        forespørselBehandlingTjeneste.settForespørselTilUtgått(new SaksnummerDto(SAKSNUMMMER), null, null);
+        forespørselBehandlingTjeneste.settForespørslerTilUtgått(new SaksnummerDto(SAKSNUMMMER), null, null);
 
         clearHibernateCache();
 
@@ -244,6 +244,57 @@ public class ForespørselBehandlingTjenesteImplTest extends EntityManagerAwareTe
         assertThat(lagret.get().getStatus()).isEqualTo(ForespørselStatus.UTGÅTT);
         var lagret2 = forespørselRepository.hentForespørsel(forespørselUuid2);
         assertThat(lagret2.get().getStatus()).isEqualTo(ForespørselStatus.UTGÅTT);
+    }
+
+    @Test
+    public void skal_sette_forespørsel_for_fagsak_til_utgått_selvom_inntektsmelding_er_motatt() {
+        var forespørselUuid = forespørselRepository.lagreForespørsel(SKJÆRINGSTIDSPUNKT, YTELSETYPE, AKTØR_ID, BRREG_ORGNUMMER, SAKSNUMMMER,
+            FØRSTE_UTTAKSDATO);
+        forespørselRepository.oppdaterArbeidsgiverNotifikasjonSakId(forespørselUuid, SAK_ID);
+        var forespørselUuid2 = forespørselRepository.lagreForespørsel(SKJÆRINGSTIDSPUNKT.plusDays(2),
+            YTELSETYPE,
+            AKTØR_ID,
+            BRREG_ORGNUMMER,
+            SAKSNUMMMER,
+            FØRSTE_UTTAKSDATO);
+        forespørselRepository.oppdaterArbeidsgiverNotifikasjonSakId(forespørselUuid2, "2");
+
+        forespørselBehandlingTjeneste.ferdigstillForespørsel(forespørselUuid, new AktørIdEntitet(AKTØR_ID), new OrganisasjonsnummerDto(BRREG_ORGNUMMER), FØRSTE_UTTAKSDATO, LukkeÅrsak.ORDINÆR_INNSENDING);
+
+        forespørselBehandlingTjeneste.settForespørslerTilUtgått(new SaksnummerDto(SAKSNUMMMER), null, null);
+
+        clearHibernateCache();
+
+        var lagretFp1 = forespørselRepository.hentForespørsel(forespørselUuid);
+        assertThat(lagretFp1.get().getStatus()).isEqualTo(ForespørselStatus.UTGÅTT);
+        var lagret2Fp2 = forespørselRepository.hentForespørsel(forespørselUuid2);
+        assertThat(lagret2Fp2.get().getStatus()).isEqualTo(ForespørselStatus.UTGÅTT);
+    }
+
+    @Test
+    public void skal_sette_forespørsel_for_fagsak_med_gitt_orgnummer_og_stp_til_utgått() {
+        var forespørselUuid = forespørselRepository.lagreForespørsel(SKJÆRINGSTIDSPUNKT, YTELSETYPE, AKTØR_ID, BRREG_ORGNUMMER, SAKSNUMMMER,
+            FØRSTE_UTTAKSDATO);
+        forespørselRepository.oppdaterArbeidsgiverNotifikasjonSakId(forespørselUuid, SAK_ID);
+        var stp2 = SKJÆRINGSTIDSPUNKT.plusDays(2);
+        var forespørselUuid2 = forespørselRepository.lagreForespørsel(stp2,
+            YTELSETYPE,
+            AKTØR_ID,
+            BRREG_ORGNUMMER,
+            SAKSNUMMMER,
+            FØRSTE_UTTAKSDATO.plusDays(2));
+        forespørselRepository.oppdaterArbeidsgiverNotifikasjonSakId(forespørselUuid2, "2");
+
+        forespørselBehandlingTjeneste.ferdigstillForespørsel(forespørselUuid, new AktørIdEntitet(AKTØR_ID), new OrganisasjonsnummerDto(BRREG_ORGNUMMER), FØRSTE_UTTAKSDATO, LukkeÅrsak.ORDINÆR_INNSENDING);
+
+        forespørselBehandlingTjeneste.settForespørslerTilUtgått(new SaksnummerDto(SAKSNUMMMER), new OrganisasjonsnummerDto(BRREG_ORGNUMMER), stp2);
+
+        clearHibernateCache();
+
+        var lagretFp1 = forespørselRepository.hentForespørsel(forespørselUuid);
+        assertThat(lagretFp1.get().getStatus()).isEqualTo(ForespørselStatus.FERDIG);
+        var lagretFp2 = forespørselRepository.hentForespørsel(forespørselUuid2);
+        assertThat(lagretFp2.get().getStatus()).isEqualTo(ForespørselStatus.UTGÅTT);
     }
 
     @Test


### PR DESCRIPTION
Dersom en forespørsel har status ferdig, (inntektsmelding er mottatt), settes forespørsel likevel til ugått. Dette gjør at arbeidsgiver ikke kan sende inn endringer. Hindret i front end. Det er ikke mulig å sette ferdig oppgave til utgått i arb.giverportalen så den vil ha status utført.