### PR TITLE
Bruk task-saksnummer mot joark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <sonar.projectKey>navikt_ft-inntektsmelding</sonar.projectKey>
 
         <felles.version>7.3.4</felles.version>
-        <prosesstask.version>5.0.19</prosesstask.version>
+        <prosesstask.version>5.0.20</prosesstask.version>
         <fp-kontrakter.version>9.1.22</fp-kontrakter.version>
     </properties>
 

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/task/SendTilJoarkTask.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/task/SendTilJoarkTask.java
@@ -18,7 +18,6 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
 public class SendTilJoarkTask implements ProsessTaskHandler {
     private static final Logger LOG = LoggerFactory.getLogger(SendTilJoarkTask.class);
     public static final String KEY_INNTEKTSMELDING_ID = "inntektsmeldingId";
-    public static final String KEY_SAKSNUMMER = "saksnummer";
 
     private InntektsmeldingTjeneste inntektsmeldingTjeneste;
     private InntektsmeldingXMLTjeneste inntektsmeldingXMLTjeneste;
@@ -43,7 +42,7 @@ public class SendTilJoarkTask implements ProsessTaskHandler {
     @Override
     public void doTask(ProsessTaskData prosessTaskData) {
         var inntektsmeldingId = Integer.parseInt(prosessTaskData.getPropertyValue(KEY_INNTEKTSMELDING_ID));
-        var fagsysteSaksnummer = prosessTaskData.getPropertyValue(KEY_SAKSNUMMER);
+        var fagsysteSaksnummer = prosessTaskData.getSaksnummer();
         LOG.info("Starter task for oversending til joark for saksnummer {}", fagsysteSaksnummer);
 
         var inntektsmelding = inntektsmeldingTjeneste.hentInntektsmelding(inntektsmeldingId);

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjeneste.java
@@ -99,8 +99,8 @@ public class InntektsmeldingTjeneste {
 
     private void opprettTaskForSendTilJoark(Long imId, String fagsystemSaksnummer) {
         var task = ProsessTaskData.forProsessTask(SendTilJoarkTask.class);
+        task.setSaksnummer(fagsystemSaksnummer);
         task.setProperty(SendTilJoarkTask.KEY_INNTEKTSMELDING_ID, imId.toString());
-        task.setProperty(SendTilJoarkTask.KEY_SAKSNUMMER, fagsystemSaksnummer);
         task.setCallIdFraEksisterende();
         prosessTaskTjeneste.lagre(task);
         LOG.info("Opprettet task for oversending til joark");

--- a/src/main/java/no/nav/familie/inntektsmelding/overstyring/InntektsmeldingOverstyringTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/overstyring/InntektsmeldingOverstyringTjeneste.java
@@ -3,14 +3,13 @@ package no.nav.familie.inntektsmelding.overstyring;
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
-import no.nav.familie.inntektsmelding.typer.dto.SaksnummerDto;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingEntitet;
 import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingRepository;
 import no.nav.familie.inntektsmelding.imdialog.task.SendTilJoarkTask;
+import no.nav.familie.inntektsmelding.typer.dto.SaksnummerDto;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
@@ -42,8 +41,8 @@ public class InntektsmeldingOverstyringTjeneste {
 
     private void opprettTaskForSendTilJoark(Long imId, SaksnummerDto fagsystemSaksnummer) {
         var task = ProsessTaskData.forProsessTask(SendTilJoarkTask.class);
+        task.setSaksnummer(fagsystemSaksnummer.saksnr());
         task.setProperty(SendTilJoarkTask.KEY_INNTEKTSMELDING_ID, imId.toString());
-        task.setProperty(SendTilJoarkTask.KEY_SAKSNUMMER, fagsystemSaksnummer.saksnr());
         task.setCallIdFraEksisterende();
         prosessTaskTjeneste.lagre(task);
         LOG.info("Opprettet task for oversending til joark");


### PR DESCRIPTION
Tingen er at prosesstask bruker PTData.getSaksnummer() til å sette MDC-kontekst. Vi kommer tilbake til header-saksnummer.

@oyvemb Jeg har ikke tatt tilsvarende makeover på OpprettForespørselTask. Prosesstask har standardisert setter+getter for aktørId, saksnummer, behandlingUuid . Kan være greit å gjøre endring før prodsetting.

Generelt og redaksjonelt for å være konsistent med fpsak/k9sak: 
* Jeg ser saksnummer, fagsakSaksnummer og fagsystemSaksnummer + SaksnummerDto. Selv om det er noe styr med Fager-saksnummer, så ville jeg brukt "saksnummer" for "våre" (FP + K9 har etablerte begrep) og fager eller arbeidsgiverSaksnummer for andre begrep.
* Nummer eller Nr. Er det noen grunn til å ikke spell-out nummer? Tenk lesbarhet.
* Domenetyper blir lett en runddans med varianter som tar inn Jackson og/eller Hibernate.  Ta gjerne en titt på disse. En mulighet er å skille Type, TypeDto, TypeDao selv om det blir flere klasser/records. En kontrakt vil gjerne ha Dto + Jackson. En domenetype i felles vil ha minimale deps og helst ikke ta inn noe eksternt (som ikke skal inn i alle moduler i alle apps).