### PR TITLE
POFIM 144 – Vis første fraværsdato på sak for K9

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -52,7 +52,9 @@ public interface ForespørselBehandlingTjeneste {
 
     void settForespørselTilUtgått(SaksnummerDto saksnummerDto, OrganisasjonsnummerDto orgnummer, LocalDate skjæringstidspunkt);
 
-    void settForespørselTilUtgått(ForespørselEntitet eksisterendeForespørsel, boolean skalOppdatereArbeidsgiverNotifikasjon);
+    void settForespørselTilUtgått(ForespørselEntitet eksisterendeForespørsel,
+                                  boolean skalOppdatereArbeidsgiverNotifikasjon,
+                                  boolean visFraværsdatoPåSak);
 
     void opprettNyBeskjedMedEksternVarsling(SaksnummerDto fagsakSaksnummer,
                                             OrganisasjonsnummerDto organisasjonsnummer);

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -2,7 +2,6 @@ package no.nav.familie.inntektsmelding.forespørsel.tjenester;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -44,7 +43,7 @@ public interface ForespørselBehandlingTjeneste {
                             AktørIdEntitet aktørId,
                             SaksnummerDto fagsakSaksnummer,
                             OrganisasjonsnummerDto organisasjonsnummer,
-                            LocalDate skjæringstidspunkt, LocalDate førsteUttaksdato);
+                            LocalDate skjæringstidspunkt, LocalDate førsteUttaksdato, boolean visFraværsdatoPåSak);
 
     void lukkForespørsel(SaksnummerDto fagsakSaksnummer, OrganisasjonsnummerDto orgnummerDto, LocalDate skjæringstidspunkt);
 

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTekster.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTekster.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import no.nav.familie.inntektsmelding.integrasjoner.arbeidsgivernotifikasjon.Merkelapp;
 import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.Organisasjon;
+import no.nav.familie.inntektsmelding.koder.ForespørselStatus;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 
 class ForespørselTekster {
@@ -20,11 +21,21 @@ class ForespørselTekster {
     private static final String TILLEGGSINFORMASJON_UTFØRT_EKSTERN = "Utført i Altinn eller i bedriftens lønns- og personalsystem";
     private static final String TILLEGGSINFORMASJON_UTGÅTT = "Du trenger ikke lenger å sende denne inntektsmeldingen";
 
+    private static final String TILLEGGSINFORMASJON_FØRSTE_FRAVÆRSDAG = "For første fraværsdag %s";
+    private static final String TILLEGGSINFORMASJON_FØRSTE_FRAVÆRSDAG_UTGÅTT = " Du trenger ikke lenger å sende inntektsmelding for første fraværsdag  %s";
+
     public static String lagTilleggsInformasjon(LukkeÅrsak årsak) {
         return switch (årsak) {
             case EKSTERN_INNSENDING -> TILLEGGSINFORMASJON_UTFØRT_EKSTERN;
             case UTGÅTT -> TILLEGGSINFORMASJON_UTGÅTT;
             default -> null;
+        };
+    }
+
+    public static String lagTilleggsInformasjonMedDato(ForespørselStatus forespørselStatus , LocalDate stp) {
+        return switch (forespørselStatus) {
+            case UNDER_BEHANDLING, FERDIG -> String.format(TILLEGGSINFORMASJON_FØRSTE_FRAVÆRSDAG, stp.format(DateTimeFormatter.ofPattern("dd.MM.yy")));
+            case UTGÅTT -> String.format(TILLEGGSINFORMASJON_FØRSTE_FRAVÆRSDAG_UTGÅTT, stp.format(DateTimeFormatter.ofPattern("dd.MM.yy")));
         };
     }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTask.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTask.java
@@ -60,7 +60,7 @@ public class OpprettForespørselTask implements ProsessTaskHandler {
             return;
         }
         // K9 trenger ikke førsteUttaksdato, setter alltid null her
-        forespørselBehandlingTjeneste.opprettForespørsel(ytelsetype, aktørId, fagsakSaksnummer, organisasjonsnummer, skjæringstidspunkt, null);
+        forespørselBehandlingTjeneste.opprettForespørsel(ytelsetype, aktørId, fagsakSaksnummer, organisasjonsnummer, skjæringstidspunkt, null, true);
         MetrikkerTjeneste.loggForespørselOpprettet(ytelsetype);
 
     }

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/SettForespørselTilUtgåttTask.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/SettForespørselTilUtgåttTask.java
@@ -53,7 +53,7 @@ public class SettForespørselTilUtgåttTask implements ProsessTaskHandler {
         }
 
         boolean skalOppdatereArbeidsgiverNotifikasjon = forespørsel.getStatus() == ForespørselStatus.UNDER_BEHANDLING;
-        forespørselBehandlingTjeneste.settForespørselTilUtgått(forespørsel, skalOppdatereArbeidsgiverNotifikasjon);
+        forespørselBehandlingTjeneste.settForespørselTilUtgått(forespørsel, skalOppdatereArbeidsgiverNotifikasjon, true);
         MetrikkerTjeneste.loggForespørselLukkEkstern(forespørsel);
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjon.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjon.java
@@ -5,7 +5,7 @@ import java.time.OffsetDateTime;
 
 public interface ArbeidsgiverNotifikasjon {
 
-    String opprettSak(String grupperingsid, Merkelapp merkelapp, String virksomhetsnummer, String saksTittel, URI lenke);
+    String opprettSak(String grupperingsid, Merkelapp merkelapp, String virksomhetsnummer, String saksTittel, URI lenke, String tilleggsinformasjon);
 
     String oppdaterSakTilleggsinformasjon(String id, String overstyrtTillagsinformasjon);
 

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonTjeneste.java
@@ -30,7 +30,8 @@ class ArbeidsgiverNotifikasjonTjeneste implements ArbeidsgiverNotifikasjon {
     }
 
     @Override
-    public String opprettSak(String grupperingsid, Merkelapp merkelapp, String virksomhetsnummer, String saksTittel, URI lenke) {
+    public String opprettSak(String grupperingsid, Merkelapp merkelapp, String virksomhetsnummer, String saksTittel, URI lenke,
+                             String tilleggsinformasjon) {
 
         var request = NySakMutationRequest.builder()
             .setGrupperingsid(grupperingsid)
@@ -40,8 +41,11 @@ class ArbeidsgiverNotifikasjonTjeneste implements ArbeidsgiverNotifikasjon {
             .setLenke(lenke.toString())
             .setInitiellStatus(SaksStatus.UNDER_BEHANDLING)
             .setOverstyrStatustekstMed(SAK_STATUS_TEKST)
-            .setMottakere(List.of(lagAltinnMottakerInput()))
-            .build();
+            .setMottakere(List.of(lagAltinnMottakerInput()));
+
+        if (tilleggsinformasjon != null) {
+            request.setTilleggsinformasjon(tilleggsinformasjon);
+        }
 
         var projection = new NySakResultatResponseProjection().typename()
             .onNySakVellykket(new NySakVellykketResponseProjection().id())
@@ -52,7 +56,7 @@ class ArbeidsgiverNotifikasjonTjeneste implements ArbeidsgiverNotifikasjon {
             .onUkjentProdusent(new UkjentProdusentResponseProjection().feilmelding())
             .onUkjentRolle(new UkjentRolleResponseProjection().feilmelding());
 
-        return klient.opprettSak(request, projection);
+        return klient.opprettSak(request.build(), projection);
     }
 
     @Override

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImplTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteImplTest.java
@@ -485,7 +485,7 @@ public class ForespørselBehandlingTjenesteImplTest extends EntityManagerAwareTe
         var sakTittel = ForespørselTekster.lagSaksTittel(personInfo.mapFulltNavn(), personInfo.fødselsdato());
 
         lenient().when(personTjeneste.hentPersonInfoFraAktørId(new AktørIdEntitet(aktørId), ytelsetype)).thenReturn(personInfo);
-        lenient().when(arbeidsgiverNotifikasjon.opprettSak(any(), any(), eq(brregOrgnummer), eq(sakTittel), any())).thenReturn(sakId);
+        lenient().when(arbeidsgiverNotifikasjon.opprettSak(any(), any(), eq(brregOrgnummer), eq(sakTittel), any(), any())).thenReturn(sakId);
         lenient().when(arbeidsgiverNotifikasjon.opprettOppgave(any(), any(), any(), eq(brregOrgnummer), any(), any(), any(), any()))
             .thenReturn(oppgaveId);
     }

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTaskTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTaskTest.java
@@ -1,6 +1,7 @@
 package no.nav.familie.inntektsmelding.forespørsel.tjenester.task;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -42,7 +43,7 @@ class OpprettForespørselTaskTest {
         task.doTask(taskdata);
 
         verify(forespørselBehandlingTjeneste).opprettForespørsel(ytelsetype, aktørId, fagsakSaksnummer, organisasjon, skjæringstidspunkt,
-            null, false );
+            null, true );
     }
 
     @Test
@@ -61,6 +62,6 @@ class OpprettForespørselTaskTest {
 
         task.doTask(taskdata);
 
-        verify(forespørselBehandlingTjeneste, times(0)).opprettForespørsel(any(), any(), any(), any(), any(), any(), false);
+        verify(forespørselBehandlingTjeneste, times(0)).opprettForespørsel(any(), any(), any(), any(), any(), any(), eq((true)));
     }
 }

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTaskTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTaskTest.java
@@ -42,7 +42,7 @@ class OpprettForespørselTaskTest {
         task.doTask(taskdata);
 
         verify(forespørselBehandlingTjeneste).opprettForespørsel(ytelsetype, aktørId, fagsakSaksnummer, organisasjon, skjæringstidspunkt,
-            null);
+            null, false );
     }
 
     @Test
@@ -61,6 +61,6 @@ class OpprettForespørselTaskTest {
 
         task.doTask(taskdata);
 
-        verify(forespørselBehandlingTjeneste, times(0)).opprettForespørsel(any(), any(), any(), any(), any(), any());
+        verify(forespørselBehandlingTjeneste, times(0)).opprettForespørsel(any(), any(), any(), any(), any(), any(), false);
     }
 }

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/SettForespørselTilUtgåttTaskTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/SettForespørselTilUtgåttTaskTest.java
@@ -36,7 +36,7 @@ class SettForespørselTilUtgåttTaskTest {
 
         task.doTask(taskdata);
 
-        verify(forespørselBehandlingTjeneste).settForespørselTilUtgått(entitet, true, false);
+        verify(forespørselBehandlingTjeneste).settForespørselTilUtgått(entitet, true, true);
     }
 
     @Test
@@ -51,6 +51,6 @@ class SettForespørselTilUtgåttTaskTest {
 
         task.doTask(taskdata);
 
-        verify(forespørselBehandlingTjeneste, times(0)).settForespørselTilUtgått(any(ForespørselEntitet.class), eq(true), false);
+        verify(forespørselBehandlingTjeneste, times(0)).settForespørselTilUtgått(any(ForespørselEntitet.class), eq(true), eq(true));
     }
 }

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/SettForespørselTilUtgåttTaskTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/SettForespørselTilUtgåttTaskTest.java
@@ -36,7 +36,7 @@ class SettForespørselTilUtgåttTaskTest {
 
         task.doTask(taskdata);
 
-        verify(forespørselBehandlingTjeneste).settForespørselTilUtgått(entitet, true);
+        verify(forespørselBehandlingTjeneste).settForespørselTilUtgått(entitet, true, false);
     }
 
     @Test
@@ -51,6 +51,6 @@ class SettForespørselTilUtgåttTaskTest {
 
         task.doTask(taskdata);
 
-        verify(forespørselBehandlingTjeneste, times(0)).settForespørselTilUtgått(any(ForespørselEntitet.class), eq(true));
+        verify(forespørselBehandlingTjeneste, times(0)).settForespørselTilUtgått(any(ForespørselEntitet.class), eq(true), false);
     }
 }

--- a/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonTjenesteTest.java
@@ -41,7 +41,7 @@ class ArbeidsgiverNotifikasjonTjenesteTest {
 
         var requestCaptor = ArgumentCaptor.forClass(NySakMutationRequest.class);
 
-        tjeneste.opprettSak(expectedGrupperingsid, expectedMerkelapp, expectedVirksomhetsnummer, expectedTittel, URI.create(expectedLenke));
+        tjeneste.opprettSak(expectedGrupperingsid, expectedMerkelapp, expectedVirksomhetsnummer, expectedTittel, URI.create(expectedLenke), null);
 
         Mockito.verify(klient).opprettSak(requestCaptor.capture(), any(NySakResultatResponseProjection.class));
 


### PR DESCRIPTION
## Bakgrunn
For pleiepenger og de andre ytelsene i k9 må vi ofte etterspørre inntektsmelding for flere skjæringstidspunkter. Vi har derfor behov for å vise frem skæringstidspunktet på saken slik at arbeidsgiver kan se hva som skiller de forskjellige oppgavene. 

Jira oppgave: https://jira.adeo.no/browse/POFIM-144

## Løsning
Viser dato sammen med tilleggsinformasjonen slik som PO helse gjør det, men med litt egne tekster.

Siden foreldrepenger ikke ønsker å vise dato har jeg lagt til et `visFraværsdatoPåSak` flagg i `opprettForespørsel` og `settForespørselTilUtgått` som settes til `true` dersom det kommer fra `OpprettForespørselTask` og `SettForespørselTilUtgåttTask` som k9 bruker. Det settes til `false` dersom det kommer fra endepunktene `/opprett` og `/sett-til-utgatt` som foreldrepenger bruker. 

For ferdigstilling av oppgave  / sak har jeg lagd en egen sjekk for k9-ytelser siden vi her bruker samme endepunkt. 