### PR TITLE
Vis første fraværsdato for opprettet oppgave i sakslisten

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -2,7 +2,6 @@ package no.nav.familie.inntektsmelding.forespørsel.tjenester;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -44,7 +43,9 @@ public interface ForespørselBehandlingTjeneste {
                             AktørIdEntitet aktørId,
                             SaksnummerDto fagsakSaksnummer,
                             OrganisasjonsnummerDto organisasjonsnummer,
-                            LocalDate skjæringstidspunkt, LocalDate førsteUttaksdato);
+                            LocalDate skjæringstidspunkt,
+                            LocalDate førsteUttaksdato,
+                            String tilleggsinfo);
 
     void lukkForespørsel(SaksnummerDto fagsakSaksnummer, OrganisasjonsnummerDto orgnummerDto, LocalDate skjæringstidspunkt);
 

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTask.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTask.java
@@ -1,6 +1,7 @@
 package no.nav.familie.inntektsmelding.forespørsel.tjenester.task;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -59,8 +60,10 @@ public class OpprettForespørselTask implements ProsessTaskHandler {
                 organisasjonsnummer.orgnr(), skjæringstidspunkt, fagsakSaksnummer.saksnr(), ytelsetype);
             return;
         }
+
+        String tilleggsinfo = String.format("For første fraværsdag %s", skjæringstidspunkt.format(DateTimeFormatter.ofPattern("dd.MM.yy")));
         // K9 trenger ikke førsteUttaksdato, setter alltid null her
-        forespørselBehandlingTjeneste.opprettForespørsel(ytelsetype, aktørId, fagsakSaksnummer, organisasjonsnummer, skjæringstidspunkt, null);
+        forespørselBehandlingTjeneste.opprettForespørsel(ytelsetype, aktørId, fagsakSaksnummer, organisasjonsnummer, skjæringstidspunkt, null, tilleggsinfo);
         MetrikkerTjeneste.loggForespørselOpprettet(ytelsetype);
 
     }

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTaskTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTaskTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -41,8 +42,10 @@ class OpprettForespørselTaskTest {
 
         task.doTask(taskdata);
 
+        String tilleggsinfo = String.format("For første fraværsdag %s", skjæringstidspunkt.format(DateTimeFormatter.ofPattern("dd.MM.yy")));
+
         verify(forespørselBehandlingTjeneste).opprettForespørsel(ytelsetype, aktørId, fagsakSaksnummer, organisasjon, skjæringstidspunkt,
-            null);
+            null, tilleggsinfo);
     }
 
     @Test
@@ -61,6 +64,6 @@ class OpprettForespørselTaskTest {
 
         task.doTask(taskdata);
 
-        verify(forespørselBehandlingTjeneste, times(0)).opprettForespørsel(any(), any(), any(), any(), any(), any());
+        verify(forespørselBehandlingTjeneste, times(0)).opprettForespørsel(any(), any(), any(), any(), any(), any(), any());
     }
 }


### PR DESCRIPTION
## Bakgrunn
For pleiepenger og de andre ytelsene i k9 må vi ofte etterspørre inntektsmelding for flere skjæringstidspunkter. Vi har derfor behov for å vise frem skæringstidspunktet på saken slik at arbeidsgiver kan se hva som skiller de forskjellige oppgavene. 

Jira oppgave: https://jira.adeo.no/browse/POFIM-144

## Løsning
Viser dato sammen med tilleggsinformasjonen slik som PO helse gjør det, men med litt egen tekst. 

Starter først med opprettet oppgave for å få feedback på hvordan det ser ut.