### PR TITLE
Setter refusjonopphørsdato til null istedenfor 9999-12-31

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/overstyring/InntektsmeldingOverstyringMapper.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/overstyring/InntektsmeldingOverstyringMapper.java
@@ -27,7 +27,7 @@ class InntektsmeldingOverstyringMapper {
             .medOpprettetAv(dto.opprettetAv())
             .medMånedInntekt(dto.inntekt())
             .medMånedRefusjon(dto.refusjon())
-            .medRefusjonOpphørsdato(finnOpphørsdato(dto.refusjonsendringer()).orElse(Tid.TIDENES_ENDE))
+            .medRefusjonOpphørsdato(finnOpphørsdato(dto.refusjonsendringer()).orElse(null))
             .medStartDato(dto.startdato())
             .medYtelsetype(KodeverkMapper.mapYtelsetype(dto.ytelse()))
             .medBortfaltNaturalytelser(mapBortfalteNaturalytelser(dto.bortfaltNaturalytelsePerioder()))


### PR DESCRIPTION
IM fra altinn bruker null. Dette fører til litt forskjellig oppførsel i k9-sak.
Med mindre fp-sak har behov for at feltet != null så tror jeg denne er grei.
https://jira.adeo.no/browse/POFIM-151