### PR TITLE
Legger til azuregruppene for saksbehandlere

### DIFF
--- a/.deploy/fp/dev-gcp-teamforeldrepenger.json
+++ b/.deploy/fp/dev-gcp-teamforeldrepenger.json
@@ -14,7 +14,8 @@
     "https://fpinntektsmelding.intern.dev.nav.no"
   ],
   "groups": [
-    "f1b82579-c5b5-4617-9673-8ace5ff67f63"
+    "f1b82579-c5b5-4617-9673-8ace5ff67f63",
+    "27e77109-fef2-48ce-a174-269074490353"
   ],
   "db": {
     "dbTier": "db-f1-micro",

--- a/.deploy/fp/prod-gcp-teamforeldrepenger.json
+++ b/.deploy/fp/prod-gcp-teamforeldrepenger.json
@@ -14,7 +14,8 @@
     "https://fpinntektsmelding.intern.nav.no"
   ],
   "groups": [
-    "0d226374-4748-4367-a38a-062dcad70034"
+    "0d226374-4748-4367-a38a-062dcad70034",
+    "73107205-17ec-4a07-a56e-e0a8542f90c9"
   ],
   "db": {
     "dbTier": "db-custom-1-3840",


### PR DESCRIPTION
Ref https://nav-it.slack.com/archives/CEKQHNLLU/p1735903040566749
Jeg har ikke tilgang til Entra ID Portal, men fant at man kunne verifisere ved å trikse med url på myaccount uten å være medlem av aktuell gruppe selv.

saksbehandler prod: https://myaccount.microsoft.com/groups/73107205-17ec-4a07-a56e-e0a8542f90c9

saksbehandler dev: https://myaccount.microsoft.com/groups/27e77109-fef2-48ce-a174-269074490353 (bytt til preprod-ident for å se gruppen)