### PR TITLE
Legg til info om innlogget bruker endepunkt

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/person/PersonTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/person/PersonTjeneste.java
@@ -29,6 +29,8 @@ import no.nav.pdl.TelefonnummerResponseProjection;
 import no.nav.vedtak.exception.IntegrasjonException;
 import no.nav.vedtak.exception.VLException;
 import no.nav.vedtak.felles.integrasjon.person.Persondata;
+import no.nav.vedtak.sikkerhet.kontekst.IdentType;
+import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
 
 @ApplicationScoped
 public class PersonTjeneste {
@@ -79,6 +81,14 @@ public class PersonTjeneste {
     public PersonIdent finnPersonIdentForAktørId(AktørIdEntitet aktørIdEntitet) {
         return hentPersonidentForAktørId(aktørIdEntitet).orElseThrow(
             () -> new IllegalStateException("Finner ikke personnummer for id " + aktørIdEntitet));
+    }
+
+    public PersonInfo hentInnloggetPerson(Ytelsetype ytelsetype) {
+        if (!KontekstHolder.harKontekst() || !IdentType.EksternBruker.equals(KontekstHolder.getKontekst().getIdentType())) {
+            throw new IllegalStateException("Mangler innlogget bruker kontekst.");
+        }
+        var pid = KontekstHolder.getKontekst().getUid();
+        return hentPersonFraIdent(PersonIdent.fra(pid), ytelsetype);
     }
 
     private LocalDate mapFødselsdato(Person person) {

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/HentInnloggetBrukerRequestDto.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/HentInnloggetBrukerRequestDto.java
@@ -1,0 +1,11 @@
+package no.nav.familie.inntektsmelding.refusjonomsorgsdagerarbeidsgiver.rest;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+
+public record HentInnloggetBrukerRequestDto(@NotNull Ytelsetype ytelseType,
+                                            @NotNull @Pattern(regexp = "^\\d{9}$") @Valid String organisasjonsnummer) {
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/InnloggetBrukerDto.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/InnloggetBrukerDto.java
@@ -2,4 +2,8 @@ package no.nav.familie.inntektsmelding.refusjonomsorgsdagerarbeidsgiver.rest;
 
 import jakarta.validation.constraints.NotNull;
 
-public record InnloggetBrukerDto(@NotNull String fornavn, String mellomnavn, @NotNull String etternavn, String telefon) {}
+public record InnloggetBrukerDto(@NotNull String fornavn, String mellomnavn, @NotNull String etternavn, String telefon, @NotNull String organisasjonsnummer, @NotNull String organisasjonsnavn) {
+    public static InnloggetBrukerDto tom() {
+        return new InnloggetBrukerDto(null, null, null, null, null, null);
+    }
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/InnloggetBrukerDto.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/InnloggetBrukerDto.java
@@ -1,0 +1,5 @@
+package no.nav.familie.inntektsmelding.refusjonomsorgsdagerarbeidsgiver.rest;
+
+import jakarta.validation.constraints.NotNull;
+
+public record InnloggetBrukerDto(@NotNull String fornavn, String mellomnavn, @NotNull String etternavn, String telefon) {}

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/InnloggetBrukerDto.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/InnloggetBrukerDto.java
@@ -2,8 +2,11 @@ package no.nav.familie.inntektsmelding.refusjonomsorgsdagerarbeidsgiver.rest;
 
 import jakarta.validation.constraints.NotNull;
 
-public record InnloggetBrukerDto(@NotNull String fornavn, String mellomnavn, @NotNull String etternavn, String telefon, @NotNull String organisasjonsnummer, @NotNull String organisasjonsnavn) {
-    public static InnloggetBrukerDto tom() {
-        return new InnloggetBrukerDto(null, null, null, null, null, null);
-    }
+public record InnloggetBrukerDto(
+    @NotNull String fornavn,
+    String mellomnavn,
+    @NotNull String etternavn,
+    String telefon,
+    @NotNull String organisasjonsnummer,
+    @NotNull String organisasjonsnavn) {
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/RefusjonOmsorgsdagerArbeidsgiverRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/RefusjonOmsorgsdagerArbeidsgiverRest.java
@@ -80,9 +80,9 @@ public class RefusjonOmsorgsdagerArbeidsgiverRest {
     @Tilgangskontrollert
     public Response hentInnloggetBruker(
         @Parameter(description = "Hvilken ytelse den innloggete brukeren skal sende inn inntektsmelding for")
-        @NotNull @QueryParam("ytelseType") Ytelsetype ytelseType,
+        @NotNull @QueryParam("ytelseType") @Valid Ytelsetype ytelseType,
         @Parameter(description = "Hvilken organisasjon den innloggete brukeren skal sende inn inntektsmelding for")
-        @NotNull @Pattern(regexp = "^\\d{9}$") @QueryParam("organisasjonsnummer") String organisasjonsnummer
+        @NotNull @Pattern(regexp = "^\\d{9}$") @Valid @QueryParam("organisasjonsnummer") String organisasjonsnummer
     ) {
         var dto = innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType, organisasjonsnummer);
         return Response.ok(dto).build();

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/RefusjonOmsorgsdagerArbeidsgiverRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/RefusjonOmsorgsdagerArbeidsgiverRest.java
@@ -8,9 +8,11 @@ import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -19,7 +21,9 @@ import org.slf4j.LoggerFactory;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdagerarbeidsgiver.tjenester.ArbeidstakerTjeneste;
+import no.nav.familie.inntektsmelding.refusjonomsorgsdagerarbeidsgiver.tjenester.InnloggetBrukerTjeneste;
 import no.nav.familie.inntektsmelding.server.auth.api.AutentisertMedTokenX;
 import no.nav.familie.inntektsmelding.server.auth.api.Tilgangskontrollert;
 
@@ -33,16 +37,19 @@ public class RefusjonOmsorgsdagerArbeidsgiverRest {
 
     public static final String BASE_PATH = "/refusjon-omsorgsdager-arbeidsgiver";
     private static final String SLÅ_OPP_ARBEIDSTAKER = "/arbeidstaker";
+    private static final String INNLOGGET_BRUKER = "/innlogget-bruker";
 
     private ArbeidstakerTjeneste arbeidstakerTjeneste;
+    private InnloggetBrukerTjeneste innloggetBrukerTjeneste;
 
     RefusjonOmsorgsdagerArbeidsgiverRest() {
         // CDI
     }
 
     @Inject
-    public RefusjonOmsorgsdagerArbeidsgiverRest(ArbeidstakerTjeneste arbeidstakerTjeneste) {
+    public RefusjonOmsorgsdagerArbeidsgiverRest(ArbeidstakerTjeneste arbeidstakerTjeneste, InnloggetBrukerTjeneste innloggetBrukerTjeneste) {
         this.arbeidstakerTjeneste = arbeidstakerTjeneste;
+        this.innloggetBrukerTjeneste = innloggetBrukerTjeneste;
     }
 
     @POST
@@ -51,7 +58,10 @@ public class RefusjonOmsorgsdagerArbeidsgiverRest {
     @Operation(description = "Henter opplysninger om arbeidstaker, gitt et fødselsnummer.", tags = "imdialog")
     @Tilgangskontrollert
     public Response slåOppArbeidstaker(
-            @Parameter(description = "Datapakke som inneholder fødselsnummeret til en arbeidstaker") @NotNull @Valid SlåOppArbeidstakerDto slåOppArbeidstakerDto) {
+        @Parameter(description = "Datapakke som inneholder fødselsnummeret til en arbeidstaker")
+        @NotNull @Valid
+        SlåOppArbeidstakerDto slåOppArbeidstakerDto
+    ) {
 
         LOG.info("Slår opp arbeidstaker med fødselsnummer {}", slåOppArbeidstakerDto.fødselsnummer());
 
@@ -59,6 +69,19 @@ public class RefusjonOmsorgsdagerArbeidsgiverRest {
         if (dto == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
+        return Response.ok(dto).build();
+    }
+
+    @GET
+    @Path(INNLOGGET_BRUKER)
+    @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
+    @Operation(description = "Henter opplysninger om innlogget bruker.", tags = "imdialog")
+    @Tilgangskontrollert
+    public Response hentInnloggetBruker(
+        @Parameter(description = "Hvilken ytelse den innloggete brukeren skal sende inn inntektsmelding for")
+        @QueryParam("ytelseType") Ytelsetype ytelseType
+    ) {
+        var dto = innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType);
         return Response.ok(dto).build();
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/RefusjonOmsorgsdagerArbeidsgiverRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/RefusjonOmsorgsdagerArbeidsgiverRest.java
@@ -7,6 +7,7 @@ import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -79,9 +80,9 @@ public class RefusjonOmsorgsdagerArbeidsgiverRest {
     @Tilgangskontrollert
     public Response hentInnloggetBruker(
         @Parameter(description = "Hvilken ytelse den innloggete brukeren skal sende inn inntektsmelding for")
-        @QueryParam("ytelseType") Ytelsetype ytelseType,
+        @NotNull @QueryParam("ytelseType") Ytelsetype ytelseType,
         @Parameter(description = "Hvilken organisasjon den innloggete brukeren skal sende inn inntektsmelding for")
-        @QueryParam("organisasjonsnummer") String organisasjonsnummer
+        @NotNull @Pattern(regexp = "^\\d{9}$") @QueryParam("organisasjonsnummer") String organisasjonsnummer
     ) {
         var dto = innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType, organisasjonsnummer);
         return Response.ok(dto).build();

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/RefusjonOmsorgsdagerArbeidsgiverRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/RefusjonOmsorgsdagerArbeidsgiverRest.java
@@ -79,9 +79,11 @@ public class RefusjonOmsorgsdagerArbeidsgiverRest {
     @Tilgangskontrollert
     public Response hentInnloggetBruker(
         @Parameter(description = "Hvilken ytelse den innloggete brukeren skal sende inn inntektsmelding for")
-        @QueryParam("ytelseType") Ytelsetype ytelseType
+        @QueryParam("ytelseType") Ytelsetype ytelseType,
+        @Parameter(description = "Hvilken organisasjon den innloggete brukeren skal sende inn inntektsmelding for")
+        @QueryParam("organisasjonsnummer") String organisasjonsnummer
     ) {
-        var dto = innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType);
+        var dto = innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType, organisasjonsnummer);
         return Response.ok(dto).build();
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/RefusjonOmsorgsdagerArbeidsgiverRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/RefusjonOmsorgsdagerArbeidsgiverRest.java
@@ -7,13 +7,10 @@ import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -22,7 +19,6 @@ import org.slf4j.LoggerFactory;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdagerarbeidsgiver.tjenester.ArbeidstakerTjeneste;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdagerarbeidsgiver.tjenester.InnloggetBrukerTjeneste;
 import no.nav.familie.inntektsmelding.server.auth.api.AutentisertMedTokenX;
@@ -61,32 +57,28 @@ public class RefusjonOmsorgsdagerArbeidsgiverRest {
     public Response slåOppArbeidstaker(
         @Parameter(description = "Datapakke som inneholder fødselsnummeret til en arbeidstaker")
         @NotNull @Valid
-        SlåOppArbeidstakerDto slåOppArbeidstakerDto
+        SlåOppArbeidstakerRequestDto slåOppArbeidstakerRequestDto
     ) {
 
-        LOG.info("Slår opp arbeidstaker med fødselsnummer {}", slåOppArbeidstakerDto.fødselsnummer());
+        LOG.info("Slår opp arbeidstaker med fødselsnummer {}", slåOppArbeidstakerRequestDto.fødselsnummer());
 
-        var dto = arbeidstakerTjeneste.slåOppArbeidstaker(slåOppArbeidstakerDto.fødselsnummer(), slåOppArbeidstakerDto.ytelseType());
+        var dto = arbeidstakerTjeneste.slåOppArbeidstaker(slåOppArbeidstakerRequestDto.fødselsnummer(), slåOppArbeidstakerRequestDto.ytelseType());
         if (dto == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
         return Response.ok(dto).build();
     }
 
-    @GET
+    @POST
     @Path(INNLOGGET_BRUKER)
     @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
     @Operation(description = "Henter opplysninger om innlogget bruker.", tags = "imdialog")
     @Tilgangskontrollert
     public Response hentInnloggetBruker(
-        @Parameter(description = "Hvilken ytelse den innloggete brukeren skal sende inn inntektsmelding for")
-        @QueryParam("ytelseType") @NotNull @Valid
-        Ytelsetype ytelseType,
-        @Parameter(description = "Hvilken organisasjon den innloggete brukeren skal sende inn inntektsmelding for")
-        @QueryParam("organisasjonsnummer") @NotNull @Pattern(regexp = "^\\d{9}$") @Valid
-        String organisasjonsnummer
+        @Parameter(description = "Datapakke som inneholder ytelsestypen og organisasjonsnummeret til den innloggede brukeren")
+        @NotNull @Valid HentInnloggetBrukerRequestDto hentInnloggetBrukerRequestDto
     ) {
-        var dto = innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType, organisasjonsnummer);
+        var dto = innloggetBrukerTjeneste.hentInnloggetBruker(hentInnloggetBrukerRequestDto.ytelseType(), hentInnloggetBrukerRequestDto.organisasjonsnummer());
         return Response.ok(dto).build();
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/RefusjonOmsorgsdagerArbeidsgiverRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/RefusjonOmsorgsdagerArbeidsgiverRest.java
@@ -80,9 +80,11 @@ public class RefusjonOmsorgsdagerArbeidsgiverRest {
     @Tilgangskontrollert
     public Response hentInnloggetBruker(
         @Parameter(description = "Hvilken ytelse den innloggete brukeren skal sende inn inntektsmelding for")
-        @NotNull @QueryParam("ytelseType") @Valid Ytelsetype ytelseType,
+        @QueryParam("ytelseType") @NotNull @Valid
+        Ytelsetype ytelseType,
         @Parameter(description = "Hvilken organisasjon den innloggete brukeren skal sende inn inntektsmelding for")
-        @NotNull @Pattern(regexp = "^\\d{9}$") @Valid @QueryParam("organisasjonsnummer") String organisasjonsnummer
+        @QueryParam("organisasjonsnummer") @NotNull @Pattern(regexp = "^\\d{9}$") @Valid
+        String organisasjonsnummer
     ) {
         var dto = innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType, organisasjonsnummer);
         return Response.ok(dto).build();

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/SlåOppArbeidstakerRequestDto.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/SlåOppArbeidstakerRequestDto.java
@@ -6,6 +6,6 @@ import jakarta.validation.constraints.NotNull;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 
-public record SlåOppArbeidstakerDto(@Valid @NotNull PersonIdent fødselsnummer, @Valid @NotNull Ytelsetype ytelseType) {
+public record SlåOppArbeidstakerRequestDto(@Valid @NotNull PersonIdent fødselsnummer, @Valid @NotNull Ytelsetype ytelseType) {
 }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/tjenester/InnloggetBrukerTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/tjenester/InnloggetBrukerTjeneste.java
@@ -11,6 +11,7 @@ import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.pip.AltinnTilgangTjeneste;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdagerarbeidsgiver.rest.InnloggetBrukerDto;
+import no.nav.vedtak.exception.ManglerTilgangException;
 
 @ApplicationScoped
 public class InnloggetBrukerTjeneste {
@@ -39,7 +40,7 @@ public class InnloggetBrukerTjeneste {
         }
 
         if (altinnTilgangTjeneste.manglerTilgangTilBedriften(organisasjonsnummer)) {
-            throw new IllegalArgumentException("Innlogget bruker har ikke tilgang til organisasjonsnummer " + organisasjonsnummer);
+            throw new ManglerTilgangException("MANGLER_TILGANG_FEIL", "Innlogget bruker har ikke tilgang til organisasjonsnummer " + organisasjonsnummer);
         }
 
         return new InnloggetBrukerDto(

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/tjenester/InnloggetBrukerTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/tjenester/InnloggetBrukerTjeneste.java
@@ -15,10 +15,14 @@ import no.nav.vedtak.exception.ManglerTilgangException;
 
 @ApplicationScoped
 public class InnloggetBrukerTjeneste {
-    private final PersonTjeneste personTjeneste;
-    private final AltinnTilgangTjeneste altinnTilgangTjeneste;
-    private final OrganisasjonTjeneste organisasjonTjeneste;
+    private PersonTjeneste personTjeneste;
+    private AltinnTilgangTjeneste altinnTilgangTjeneste;
+    private OrganisasjonTjeneste organisasjonTjeneste;
     private static final Logger LOG = LoggerFactory.getLogger(InnloggetBrukerTjeneste.class);
+
+    public InnloggetBrukerTjeneste() {
+        // CDI
+    }
 
     @Inject
     public InnloggetBrukerTjeneste(PersonTjeneste personTjeneste, AltinnTilgangTjeneste altinnTilgangTjeneste, OrganisasjonTjeneste organisasjonTjeneste) {

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/tjenester/InnloggetBrukerTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/tjenester/InnloggetBrukerTjeneste.java
@@ -30,17 +30,16 @@ public class InnloggetBrukerTjeneste {
         LOG.info("Henter informasjon om innlogget bruker for ytelseType {} og orgnummer {}", ytelseType, organisasjonsnummer);
         var innloggetBruker = personTjeneste.hentInnloggetPerson(ytelseType);
         if (innloggetBruker == null) {
-            LOG.warn("Fant ikke innlogget bruker i PDL. Undersøk hvorfor.");
-            return InnloggetBrukerDto.tom();
+            throw new IllegalStateException("Fant ikke innlogget bruker i PDL.");
         }
 
         var organisasjon = organisasjonTjeneste.finnOrganisasjon(organisasjonsnummer);
         if (organisasjon == null) {
-            throw new IllegalStateException("Fant ikke organisasjon med orgnummer " + organisasjonsnummer);
+            throw new IllegalArgumentException("Fant ikke organisasjon med orgnummer " + organisasjonsnummer);
         }
 
         if (altinnTilgangTjeneste.manglerTilgangTilBedriften(organisasjonsnummer)) {
-            throw new IllegalStateException("Innlogget bruker har ikke tilgang til organisasjonsnummer " + organisasjonsnummer);
+            throw new IllegalArgumentException("Innlogget bruker har ikke tilgang til organisasjonsnummer " + organisasjonsnummer);
         }
 
         return new InnloggetBrukerDto(

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/tjenester/InnloggetBrukerTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/tjenester/InnloggetBrukerTjeneste.java
@@ -1,0 +1,29 @@
+package no.nav.familie.inntektsmelding.refusjonomsorgsdagerarbeidsgiver.tjenester;
+
+import jakarta.inject.Inject;
+
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.familie.inntektsmelding.refusjonomsorgsdagerarbeidsgiver.rest.InnloggetBrukerDto;
+
+public class InnloggetBrukerTjeneste {
+    private final PersonTjeneste personTjeneste;
+
+    @Inject
+    public InnloggetBrukerTjeneste(PersonTjeneste personTjeneste) {
+        this.personTjeneste = personTjeneste;
+    }
+
+    public InnloggetBrukerDto hentInnloggetBruker(Ytelsetype ytelseType) {
+        var innloggetBruker = personTjeneste.hentInnloggetPerson(ytelseType);
+        if (innloggetBruker == null) {
+            return new InnloggetBrukerDto(null, null, null, null);
+        }
+        return new InnloggetBrukerDto(
+            innloggetBruker.fornavn(),
+            innloggetBruker.mellomnavn(),
+            innloggetBruker.etternavn(),
+            innloggetBruker.telefonnummer()
+        );
+    }
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/server/auth/AutentiseringFilter.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/server/auth/AutentiseringFilter.java
@@ -59,7 +59,7 @@ public class AutentiseringFilter implements ContainerRequestFilter, ContainerRes
     void assertValidRequest(ContainerRequestContext req) {
         var method = getResourceinfo().getResourceMethod();
         LOG.trace("{} i klasse {}", method.getName(), method.getDeclaringClass());
-        fjernKontektsHvisFinnes();
+        fjernKontekstHvisFinnes();
         AuthenticationFilterDelegate.validerSettKontekst(getResourceinfo(), req);
         assertValidAnnotation(method, req);
     }
@@ -104,7 +104,7 @@ public class AutentiseringFilter implements ContainerRequestFilter, ContainerRes
     private void validerIkkeAutentisertKontekst() {
         var kontekst = KontekstHolder.getKontekst();
         if (!kontekst.harKontekst() || kontekst.getIdentType() != null) {
-            throw new WebApplicationException("Kan ikke kjøre uten autentisering med autentisert kontekts", Response.Status.UNAUTHORIZED);
+            throw new WebApplicationException("Kan ikke kjøre uten autentisering med autentisert kontekst", Response.Status.UNAUTHORIZED);
         }
     }
 
@@ -122,7 +122,7 @@ public class AutentiseringFilter implements ContainerRequestFilter, ContainerRes
         }
     }
 
-    private void fjernKontektsHvisFinnes() {
+    private void fjernKontekstHvisFinnes() {
         if (KontekstHolder.harKontekst()) {
             LOG.info("Kall til {} hadde kontekst {}", getResourceinfo().getResourceMethod().getName(), KontekstHolder.getKontekst().getKompaktUid());
             KontekstHolder.fjernKontekst();

--- a/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/person/PersonTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/person/PersonTjenesteTest.java
@@ -1,0 +1,99 @@
+package no.nav.familie.inntektsmelding.integrasjoner.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.pdl.Foedselsdato;
+import no.nav.pdl.Navn;
+import no.nav.pdl.Person;
+import no.nav.pdl.Telefonnummer;
+import no.nav.vedtak.sikkerhet.kontekst.IdentType;
+import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
+import no.nav.vedtak.sikkerhet.kontekst.RequestKontekst;
+
+@ExtendWith(MockitoExtension.class)
+class PersonTjenesteTest {
+    @Mock
+    private PdlKlient pdlKlientMock;
+
+    private MockedStatic<KontekstHolder> kontekstHolderMock;
+
+    private PersonTjeneste personTjeneste;
+
+    @BeforeEach
+    void setUp() {
+        personTjeneste = new PersonTjeneste(pdlKlientMock);
+        kontekstHolderMock = mockStatic(KontekstHolder.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        kontekstHolderMock.close();
+    }
+
+    @Test
+    void hentInnloggetPerson_skal_returnere_innlogget_person() {
+        var ytelseType = Ytelsetype.OMSORGSPENGER;
+        var pdlPerson = new Person();
+        var pdlNavn = new Navn();
+        pdlNavn.setFornavn("fornavn");
+        pdlNavn.setMellomnavn("mellomnavn");
+        pdlNavn.setEtternavn("etternavn");
+        var pdlTelefonnummer = new Telefonnummer();
+        pdlTelefonnummer.setLandskode("47");
+        pdlTelefonnummer.setNummer("81549300");
+        var pdlFødselsdato = new Foedselsdato();
+        pdlFødselsdato.setFoedselsdato("1997-11-23");
+
+        pdlPerson.setNavn(List.of(pdlNavn));
+        pdlPerson.setTelefonnummer(List.of(pdlTelefonnummer));
+        pdlPerson.setFoedselsdato(List.of(pdlFødselsdato));
+
+        var kontekst = RequestKontekst.forRequest("11839798115", null, IdentType.EksternBruker, null, null, new HashSet<>());
+        when(KontekstHolder.harKontekst()).thenReturn(true);
+        when(KontekstHolder.getKontekst()).thenReturn(kontekst);
+        when(pdlKlientMock.hentPerson(any(), any(), any())).thenReturn(pdlPerson);
+
+        var person = personTjeneste.hentInnloggetPerson(ytelseType);
+
+        assertEquals("fornavn", person.fornavn());
+        assertEquals("mellomnavn", person.mellomnavn());
+        assertEquals("etternavn", person.etternavn());
+        assertEquals("4781549300", person.telefonnummer());
+    }
+
+    @Test
+    void hentInnloggetPerson_skal_kaste_exception_om_man_ikke_har_kontekst() {
+        var ytelseType = Ytelsetype.OMSORGSPENGER;
+
+        when(KontekstHolder.harKontekst()).thenReturn(false);
+
+        assertThrows(IllegalStateException.class, () -> personTjeneste.hentInnloggetPerson(ytelseType));
+    }
+
+    @Test
+    void hentInnloggetPerson_skal_kaste_exception_om_identtypen_ikke_er_ekstern() {
+        var ytelseType = Ytelsetype.OMSORGSPENGER;
+
+        when(KontekstHolder.harKontekst()).thenReturn(true);
+        var kontekst = RequestKontekst.forRequest("11839798115", null, IdentType.InternBruker, null, null, new HashSet<>());
+        when(KontekstHolder.getKontekst()).thenReturn(kontekst);
+
+        assertThrows(IllegalStateException.class, () -> personTjeneste.hentInnloggetPerson(ytelseType));
+    }
+}

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/RefusjonOmsorgsdagerArbeidsgiverRestTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/RefusjonOmsorgsdagerArbeidsgiverRestTest.java
@@ -36,12 +36,12 @@ class RefusjonOmsorgsdagerArbeidsgiverRestTest {
     @Test
     void slå_opp_arbeidstaker_skal_returnere_ok_response_når_arbeidstaker_finnes() {
         var fnr = PersonIdent.fra("12345678910");
-        var dto = new SlåOppArbeidstakerDto(fnr, Ytelsetype.OMSORGSPENGER);
+        var dto = new SlåOppArbeidstakerRequestDto(fnr, Ytelsetype.OMSORGSPENGER);
         var arbeidstakerInfo = new SlåOppArbeidstakerResponseDto("fornavn", "mellomnavn", "etternavn", null);
 
         when(arbeidstakerTjenesteMock.slåOppArbeidstaker(fnr, Ytelsetype.OMSORGSPENGER)).thenReturn(arbeidstakerInfo);
 
-        Response response = rest.slåOppArbeidstaker(dto);
+        var response = rest.slåOppArbeidstaker(dto);
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         assertEquals(arbeidstakerInfo, response.getEntity());
@@ -51,11 +51,11 @@ class RefusjonOmsorgsdagerArbeidsgiverRestTest {
     @Test
     void slå_opp_arbeidstaker_skal_returnere_not_found_når_arbeidstaker_ikke_finnes() {
         var fnr = PersonIdent.fra("12345678910");
-        var dto = new SlåOppArbeidstakerDto(fnr, Ytelsetype.OMSORGSPENGER);
+        var dto = new SlåOppArbeidstakerRequestDto(fnr, Ytelsetype.OMSORGSPENGER);
 
         when(arbeidstakerTjenesteMock.slåOppArbeidstaker(fnr, Ytelsetype.OMSORGSPENGER)).thenReturn(null);
 
-        Response response = rest.slåOppArbeidstaker(dto);
+        var response = rest.slåOppArbeidstaker(dto);
 
         assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
         verify(arbeidstakerTjenesteMock).slåOppArbeidstaker(fnr, Ytelsetype.OMSORGSPENGER);
@@ -67,7 +67,7 @@ class RefusjonOmsorgsdagerArbeidsgiverRestTest {
 
         when(innloggetBrukerTjenesteMock.hentInnloggetBruker(any(), any())).thenReturn(innloggetBruker);
 
-        Response response = rest.hentInnloggetBruker(Ytelsetype.OMSORGSPENGER, "123456789");
+        var response = rest.hentInnloggetBruker(new HentInnloggetBrukerRequestDto(Ytelsetype.OMSORGSPENGER, "123456789"));
         assertEquals(response.getEntity(), innloggetBruker);
     }
 }

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/RefusjonOmsorgsdagerArbeidsgiverRestTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/RefusjonOmsorgsdagerArbeidsgiverRestTest.java
@@ -63,11 +63,11 @@ class RefusjonOmsorgsdagerArbeidsgiverRestTest {
 
     @Test
     void hent_innlogget_bruker_returnerer_ok() {
-        var innloggetBruker = new InnloggetBrukerDto("fornavn", "mellomnavn", "etternavn", "81549300");
+        var innloggetBruker = new InnloggetBrukerDto("fornavn", "mellomnavn", "etternavn", "81549300", "123456789", "organisasjonsnavn");
 
-        when(innloggetBrukerTjenesteMock.hentInnloggetBruker(any())).thenReturn(innloggetBruker);
+        when(innloggetBrukerTjenesteMock.hentInnloggetBruker(any(), any())).thenReturn(innloggetBruker);
 
-        Response response = rest.hentInnloggetBruker(Ytelsetype.OMSORGSPENGER);
+        Response response = rest.hentInnloggetBruker(Ytelsetype.OMSORGSPENGER, "123456789");
         assertEquals(response.getEntity(), innloggetBruker);
     }
 }

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/RefusjonOmsorgsdagerArbeidsgiverRestTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/RefusjonOmsorgsdagerArbeidsgiverRestTest.java
@@ -1,6 +1,7 @@
 package no.nav.familie.inntektsmelding.refusjonomsorgsdagerarbeidsgiver.rest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -15,17 +16,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdagerarbeidsgiver.tjenester.ArbeidstakerTjeneste;
+import no.nav.familie.inntektsmelding.refusjonomsorgsdagerarbeidsgiver.tjenester.InnloggetBrukerTjeneste;
 
 @ExtendWith(MockitoExtension.class)
 class RefusjonOmsorgsdagerArbeidsgiverRestTest {
     @Mock
     private ArbeidstakerTjeneste arbeidstakerTjenesteMock;
 
+    @Mock
+    private InnloggetBrukerTjeneste innloggetBrukerTjenesteMock;
+
     private RefusjonOmsorgsdagerArbeidsgiverRest rest;
 
     @BeforeEach
     void setUp() {
-        rest = new RefusjonOmsorgsdagerArbeidsgiverRest(arbeidstakerTjenesteMock);
+        rest = new RefusjonOmsorgsdagerArbeidsgiverRest(arbeidstakerTjenesteMock, innloggetBrukerTjenesteMock);
     }
 
     @Test
@@ -54,5 +59,15 @@ class RefusjonOmsorgsdagerArbeidsgiverRestTest {
 
         assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
         verify(arbeidstakerTjenesteMock).slåOppArbeidstaker(fnr, Ytelsetype.OMSORGSPENGER);
+    }
+
+    @Test
+    void hent_innlogget_bruker_returnerer_ok() {
+        var innloggetBruker = new InnloggetBrukerDto("fornavn", "mellomnavn", "etternavn", "81549300");
+
+        when(innloggetBrukerTjenesteMock.hentInnloggetBruker(any())).thenReturn(innloggetBruker);
+
+        Response response = rest.hentInnloggetBruker(Ytelsetype.OMSORGSPENGER);
+        assertEquals(response.getEntity(), innloggetBruker);
     }
 }

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/tjenester/InnloggetBrukerTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/tjenester/InnloggetBrukerTjenesteTest.java
@@ -21,6 +21,7 @@ import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.pip.AltinnTilgangTjeneste;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
+import no.nav.vedtak.exception.ManglerTilgangException;
 
 @ExtendWith(MockitoExtension.class)
 class InnloggetBrukerTjenesteTest {
@@ -121,7 +122,7 @@ class InnloggetBrukerTjenesteTest {
         when(organisasjonTjenesteMock.finnOrganisasjon("123456789")).thenReturn(organisasjon);
         when(altinnTilgangTjenesteMock.manglerTilgangTilBedriften("123456789")).thenReturn(true);
 
-        assertThrows(IllegalArgumentException.class, () -> innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType, "123456789"));
+        assertThrows(ManglerTilgangException.class, () -> innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType, "123456789"));
     }
 
 }

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/tjenester/InnloggetBrukerTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/tjenester/InnloggetBrukerTjenesteTest.java
@@ -2,6 +2,7 @@ package no.nav.familie.inntektsmelding.refusjonomsorgsdagerarbeidsgiver.tjeneste
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -13,10 +14,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.Organisasjon;
+import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.OrganisasjonTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonInfo;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.familie.inntektsmelding.pip.AltinnTilgangTjeneste;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,16 +28,68 @@ class InnloggetBrukerTjenesteTest {
     @Mock
     private PersonTjeneste personTjenesteMock;
 
+    @Mock
+    private AltinnTilgangTjeneste altinnTilgangTjenesteMock;
+
+    @Mock
+    private OrganisasjonTjeneste organisasjonTjenesteMock;
+
     private InnloggetBrukerTjeneste innloggetBrukerTjeneste;
 
     @BeforeEach
     void setUp() {
-        innloggetBrukerTjeneste = new InnloggetBrukerTjeneste(personTjenesteMock);
+        innloggetBrukerTjeneste = new InnloggetBrukerTjeneste(personTjenesteMock, altinnTilgangTjenesteMock, organisasjonTjenesteMock);
     }
 
     @Test
     void hent_innlogget_bruker_skal_returnere_innlogget_bruker() {
-        // Arrange
+        var ytelseType = Ytelsetype.OMSORGSPENGER;
+        var innloggetPerson = new PersonInfo(
+            "fornavn",
+            "mellomnavn",
+            "etternavn",
+            PersonIdent.fra("11839798115"),
+            AktørIdEntitet.dummy(),
+            LocalDate.of(1997, 11, 23),
+            "81549300"
+        );
+
+        var organisasjon = new Organisasjon(
+            "organisasjonsnavn",
+            "123456789"
+        );
+
+        when(personTjenesteMock.hentInnloggetPerson(ytelseType)).thenReturn(innloggetPerson);
+        when(organisasjonTjenesteMock.finnOrganisasjon("123456789")).thenReturn(organisasjon);
+        when(altinnTilgangTjenesteMock.manglerTilgangTilBedriften("123456789")).thenReturn(false);
+
+        var innloggetBruker = innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType, "123456789");
+
+        assertEquals("fornavn", innloggetBruker.fornavn());
+        assertEquals("mellomnavn", innloggetBruker.mellomnavn());
+        assertEquals("etternavn", innloggetBruker.etternavn());
+        assertEquals("81549300", innloggetBruker.telefon());
+        assertEquals("organisasjonsnavn", innloggetBruker.organisasjonsnavn());
+        assertEquals("123456789", innloggetBruker.organisasjonsnummer());
+        verify(personTjenesteMock).hentInnloggetPerson(ytelseType);
+    }
+
+    @Test
+    void hent_innlogget_bruker_skal_returnere_tom_dto_om_PersonTjeneste_returnerer_null() {
+        var ytelseType = Ytelsetype.OMSORGSPENGER;
+        when(personTjenesteMock.hentInnloggetPerson(ytelseType)).thenReturn(null);
+
+        var innloggetBruker = innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType, "123456789");
+
+        assertNull(innloggetBruker.fornavn());
+        assertNull(innloggetBruker.mellomnavn());
+        assertNull(innloggetBruker.etternavn());
+        assertNull(innloggetBruker.telefon());
+        verify(personTjenesteMock).hentInnloggetPerson(ytelseType);
+    }
+
+    @Test
+    void hent_innlogget_bruker_skal_kaste_exception_om_organisasjonen_ikke_finnes() {
         var ytelseType = Ytelsetype.OMSORGSPENGER;
         var innloggetPerson = new PersonInfo(
             "fornavn",
@@ -46,28 +102,33 @@ class InnloggetBrukerTjenesteTest {
         );
 
         when(personTjenesteMock.hentInnloggetPerson(ytelseType)).thenReturn(innloggetPerson);
+        when(organisasjonTjenesteMock.finnOrganisasjon("123456789")).thenReturn(null);
 
-        var innloggetBruker = innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType);
-
-        assertEquals("fornavn", innloggetBruker.fornavn());
-        assertEquals("mellomnavn", innloggetBruker.mellomnavn());
-        assertEquals("etternavn", innloggetBruker.etternavn());
-        assertEquals("81549300", innloggetBruker.telefon());
-        verify(personTjenesteMock).hentInnloggetPerson(ytelseType);
+        assertThrows(IllegalStateException.class, () -> innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType, "123456789"));
     }
 
     @Test
-    void hent_innlogget_bruker_skal_returnere_tom_dto_om_PersonTjeneste_returnerer_null() {
+    void hent_innlogget_bruker_skal_kaste_exception_om_bruker_ikke_har_tilgang_til_organisasjonen() {
         var ytelseType = Ytelsetype.OMSORGSPENGER;
-        when(personTjenesteMock.hentInnloggetPerson(ytelseType)).thenReturn(null);
+        var innloggetPerson = new PersonInfo(
+            "fornavn",
+            "mellomnavn",
+            "etternavn",
+            PersonIdent.fra("11839798115"),
+            AktørIdEntitet.dummy(),
+            LocalDate.of(1997, 11, 23),
+            "81549300"
+        );
+        var organisasjon = new Organisasjon(
+            "organisasjonsnavn",
+            "123456789"
+        );
 
-        var innloggetBruker = innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType);
+        when(personTjenesteMock.hentInnloggetPerson(ytelseType)).thenReturn(innloggetPerson);
+        when(organisasjonTjenesteMock.finnOrganisasjon("123456789")).thenReturn(organisasjon);
+        when(altinnTilgangTjenesteMock.manglerTilgangTilBedriften("123456789")).thenReturn(true);
 
-        assertNull(innloggetBruker.fornavn());
-        assertNull(innloggetBruker.mellomnavn());
-        assertNull(innloggetBruker.etternavn());
-        assertNull(innloggetBruker.telefon());
-        verify(personTjenesteMock).hentInnloggetPerson(ytelseType);
+        assertThrows(IllegalStateException.class, () -> innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType, "123456789"));
     }
 
 }

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/tjenester/InnloggetBrukerTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/tjenester/InnloggetBrukerTjenesteTest.java
@@ -1,0 +1,73 @@
+package no.nav.familie.inntektsmelding.refusjonomsorgsdagerarbeidsgiver.tjenester;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonInfo;
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
+
+@ExtendWith(MockitoExtension.class)
+class InnloggetBrukerTjenesteTest {
+    @Mock
+    private PersonTjeneste personTjenesteMock;
+
+    private InnloggetBrukerTjeneste innloggetBrukerTjeneste;
+
+    @BeforeEach
+    void setUp() {
+        innloggetBrukerTjeneste = new InnloggetBrukerTjeneste(personTjenesteMock);
+    }
+
+    @Test
+    void hent_innlogget_bruker_skal_returnere_innlogget_bruker() {
+        // Arrange
+        var ytelseType = Ytelsetype.OMSORGSPENGER;
+        var innloggetPerson = new PersonInfo(
+            "fornavn",
+            "mellomnavn",
+            "etternavn",
+            PersonIdent.fra("11839798115"),
+            AktørIdEntitet.dummy(),
+            LocalDate.of(1997, 11, 23),
+            "81549300"
+        );
+
+        when(personTjenesteMock.hentInnloggetPerson(ytelseType)).thenReturn(innloggetPerson);
+
+        var innloggetBruker = innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType);
+
+        assertEquals("fornavn", innloggetBruker.fornavn());
+        assertEquals("mellomnavn", innloggetBruker.mellomnavn());
+        assertEquals("etternavn", innloggetBruker.etternavn());
+        assertEquals("81549300", innloggetBruker.telefon());
+        verify(personTjenesteMock).hentInnloggetPerson(ytelseType);
+    }
+
+    @Test
+    void hent_innlogget_bruker_skal_returnere_tom_dto_om_PersonTjeneste_returnerer_null() {
+        var ytelseType = Ytelsetype.OMSORGSPENGER;
+        when(personTjenesteMock.hentInnloggetPerson(ytelseType)).thenReturn(null);
+
+        var innloggetBruker = innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType);
+
+        assertNull(innloggetBruker.fornavn());
+        assertNull(innloggetBruker.mellomnavn());
+        assertNull(innloggetBruker.etternavn());
+        assertNull(innloggetBruker.telefon());
+        verify(personTjenesteMock).hentInnloggetPerson(ytelseType);
+    }
+
+}

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/tjenester/InnloggetBrukerTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/tjenester/InnloggetBrukerTjenesteTest.java
@@ -1,7 +1,6 @@
 package no.nav.familie.inntektsmelding.refusjonomsorgsdagerarbeidsgiver.tjenester;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -75,17 +74,11 @@ class InnloggetBrukerTjenesteTest {
     }
 
     @Test
-    void hent_innlogget_bruker_skal_returnere_tom_dto_om_PersonTjeneste_returnerer_null() {
+    void hent_innlogget_bruker_skal_kaste_exception_om_PersonTjeneste_returnerer_null() {
         var ytelseType = Ytelsetype.OMSORGSPENGER;
         when(personTjenesteMock.hentInnloggetPerson(ytelseType)).thenReturn(null);
 
-        var innloggetBruker = innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType, "123456789");
-
-        assertNull(innloggetBruker.fornavn());
-        assertNull(innloggetBruker.mellomnavn());
-        assertNull(innloggetBruker.etternavn());
-        assertNull(innloggetBruker.telefon());
-        verify(personTjenesteMock).hentInnloggetPerson(ytelseType);
+        assertThrows(IllegalStateException.class, () -> innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType, "123456789"));
     }
 
     @Test
@@ -104,7 +97,7 @@ class InnloggetBrukerTjenesteTest {
         when(personTjenesteMock.hentInnloggetPerson(ytelseType)).thenReturn(innloggetPerson);
         when(organisasjonTjenesteMock.finnOrganisasjon("123456789")).thenReturn(null);
 
-        assertThrows(IllegalStateException.class, () -> innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType, "123456789"));
+        assertThrows(IllegalArgumentException.class, () -> innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType, "123456789"));
     }
 
     @Test
@@ -128,7 +121,7 @@ class InnloggetBrukerTjenesteTest {
         when(organisasjonTjenesteMock.finnOrganisasjon("123456789")).thenReturn(organisasjon);
         when(altinnTilgangTjenesteMock.manglerTilgangTilBedriften("123456789")).thenReturn(true);
 
-        assertThrows(IllegalStateException.class, () -> innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType, "123456789"));
+        assertThrows(IllegalArgumentException.class, () -> innloggetBrukerTjeneste.hentInnloggetBruker(ytelseType, "123456789"));
     }
 
 }


### PR DESCRIPTION
Dette PRet legger til et endepunkt som returnerer informasjon om den innloggede brukeren.

Vi må sende med organisasjonsnummeret man er "logget inn som" som en query parameter, da dette ikke er tilgjengelig i JWTen (man er ikke faktisk logget inn som den bedriften – det man ser på Min Side Arbeidsgiver er i applikasjonslaget, ikke i autentiseringslaget). Dette kan vi løse ved at Fager legger til aktivt organisasjonsnummer som et query parameter i lenken inn i løsningen vår.