### PR TITLE
Returner tom liste dersom man får en 404 fra aareg

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/aareg/AaregRestKlient.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/aareg/AaregRestKlient.java
@@ -3,19 +3,24 @@ package no.nav.familie.inntektsmelding.integrasjoner.aareg;
 import java.net.URI;
 import java.time.LocalDate;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import jakarta.enterprise.context.Dependent;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriBuilderException;
 
 import no.nav.familie.inntektsmelding.integrasjoner.aareg.dto.ArbeidsforholdDto;
+import no.nav.vedtak.exception.IntegrasjonException;
 import no.nav.vedtak.felles.integrasjon.rest.NavHeaders;
 import no.nav.vedtak.felles.integrasjon.rest.RestClient;
 import no.nav.vedtak.felles.integrasjon.rest.RestClientConfig;
 import no.nav.vedtak.felles.integrasjon.rest.RestConfig;
 import no.nav.vedtak.felles.integrasjon.rest.RestRequest;
 import no.nav.vedtak.felles.integrasjon.rest.TokenFlow;
+
+import no.nav.vedtak.mapper.json.DefaultJsonMapper;;
 
 /*
  * Dokumentasjon https://confluence.adeo.no/display/FEL/AAREG+-+Tjeneste+REST+aareg.api
@@ -45,14 +50,28 @@ public class AaregRestKlient {
         try {
             var uri = lagUriForForFinnArbeidsforholdForArbeidstaker(førsteFraværsdag, førsteFraværsdag);
             var request = RestRequest.newGET(uri, restConfig).header(NavHeaders.HEADER_NAV_PERSONIDENT, personIdent);
-            var response = restClient.send(request, ArbeidsforholdDto[].class);
-            return Arrays.asList(response);
+            var response = restClient.sendReturnUnhandled(request);
+
+            if (response.statusCode() == Response.Status.NOT_FOUND.getStatusCode()) {
+                // 404 betyr at det ikke finnes arbeidsforhold for personen, eller at personen ikke finnes
+                return Collections.emptyList();
+            }
+
+            var arbeidsforhold = DefaultJsonMapper.fromJson(response.body(), ArbeidsforholdDto[].class);
+            return Arrays.asList(arbeidsforhold);
+        } catch (IntegrasjonException e) {
+            if (e.getMessage().contains("404")) {
+                return Collections.emptyList();
+            }
+            throw e;
         } catch (UriBuilderException | IllegalArgumentException e) {
             throw new IllegalArgumentException("Utviklerfeil syntax-exception for finnArbeidsforholdForArbeidstaker");
         }
     }
 
-    /** Kun eksponert for å kunne teste URI-bygging – skal ikke brukes ellers */
+    /**
+     * Kun eksponert for å kunne teste URI-bygging – skal ikke brukes ellers
+     */
     URI lagUriForForFinnArbeidsforholdForArbeidstaker(LocalDate qfom, LocalDate qtom) {
         return UriBuilder.fromUri(restConfig.endpoint())
             .path("arbeidstaker/arbeidsforhold")

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/aareg/AaregRestKlient.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/aareg/AaregRestKlient.java
@@ -20,7 +20,7 @@ import no.nav.vedtak.felles.integrasjon.rest.RestConfig;
 import no.nav.vedtak.felles.integrasjon.rest.RestRequest;
 import no.nav.vedtak.felles.integrasjon.rest.TokenFlow;
 
-import no.nav.vedtak.mapper.json.DefaultJsonMapper;;
+import no.nav.vedtak.mapper.json.DefaultJsonMapper;
 
 /*
  * Dokumentasjon https://confluence.adeo.no/display/FEL/AAREG+-+Tjeneste+REST+aareg.api
@@ -55,6 +55,10 @@ public class AaregRestKlient {
             if (response.statusCode() == Response.Status.NOT_FOUND.getStatusCode()) {
                 // 404 betyr at det ikke finnes arbeidsforhold for personen, eller at personen ikke finnes
                 return Collections.emptyList();
+            }
+
+            if (response.statusCode() >= 400) {
+                throw new IntegrasjonException("FP-12345", "Feil ved henting av arbeidsforhold for person: " + response.body());
             }
 
             var arbeidsforhold = DefaultJsonMapper.fromJson(response.body(), ArbeidsforholdDto[].class);

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/RefusjonOmsorgsdagerArbeidsgiverRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdagerarbeidsgiver/rest/RefusjonOmsorgsdagerArbeidsgiverRest.java
@@ -2,6 +2,8 @@ package no.nav.familie.inntektsmelding.refusjonomsorgsdagerarbeidsgiver.rest;
 
 import static no.nav.familie.inntektsmelding.refusjonomsorgsdagerarbeidsgiver.rest.RefusjonOmsorgsdagerArbeidsgiverRest.BASE_PATH;
 
+import java.time.LocalDate;
+
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -14,19 +16,16 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdagerarbeidsgiver.tjenester.ArbeidstakerTjeneste;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdagerarbeidsgiver.tjenester.InnloggetBrukerTjeneste;
 import no.nav.familie.inntektsmelding.server.auth.api.AutentisertMedTokenX;
 import no.nav.familie.inntektsmelding.server.auth.api.Tilgangskontrollert;
-
-import java.time.LocalDate;
 
 @AutentisertMedTokenX
 @RequestScoped

--- a/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/aareg/AaregRestKlientTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/aareg/AaregRestKlientTest.java
@@ -20,6 +20,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import no.nav.familie.inntektsmelding.integrasjoner.aareg.dto.ArbeidsforholdDto;
+import no.nav.vedtak.exception.IntegrasjonException;
 import no.nav.vedtak.felles.integrasjon.rest.RestClient;
 import no.nav.vedtak.felles.integrasjon.rest.RestRequest;
 import no.nav.vedtak.mapper.json.DefaultJsonMapper;
@@ -102,6 +103,32 @@ class AaregRestKlientTest {
 
         // Assert
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    void skal_returnere_tom_liste_når_aareg_returnerer_404() {
+        // Arrange
+        var ident = "12345678901";
+
+        when(restClient.sendReturnUnhandled(any(RestRequest.class)))
+            .thenThrow(new IntegrasjonException("FP-12345", "404 feil"));
+
+        // Act
+        var result = aaregRestKlient.finnArbeidsforholdForArbeidstaker(ident, LocalDate.now());
+
+        // Assert
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void skal_kaste_exception_når_aareg_kaster_annen_integrasjonsexception() {
+        // Arrange
+        var ident = "12345678901";
+
+        when(restClient.sendReturnUnhandled(any(RestRequest.class)))
+            .thenThrow(new IntegrasjonException("FP-w00t", "Ukjent feil"));
+
+        assertThrows(IntegrasjonException.class, () -> aaregRestKlient.finnArbeidsforholdForArbeidstaker(ident, LocalDate.now()));
     }
 
     @Test


### PR DESCRIPTION
Om Aareg ikke finner en person, så får man en 404 feil. Siden den ikke ble catchet på noe vis av eksisterende kode, fikk man tilbake en 500 fra APIet. Det gjør at vi ikke kan differensiere mellom når en person ikke finnes, og når noe går galt rent teknisk. Det er ikke ønskelig.

Denne PRen returnerer heller en tom liste med arbeidsforhold om man får en 404 fra Aareg-integrasjonen, som gjør at vi kan vise riktig feilmelding.