### PR TITLE
Opprett workflow for å deploye k9-inntekstmelding til prod

### DIFF
--- a/.deploy/k9/prod-gcp-k9saksbehandling.json
+++ b/.deploy/k9/prod-gcp-k9saksbehandling.json
@@ -10,7 +10,10 @@
     "cpu": "500m",
     "mem": "1024Mi"
   },
-  "dbTier": "TODO",
+  "ingresses": [
+    "https://k9-inntektsmelding.intern.nav.no"
+  ],
+  "dbTier": "db-custom-1-3840",
   "dbDiskAutoresize": "true",
   "dbHighAvailability": "true",
   "dbPointInTimeRecovery": "true",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,47 +16,63 @@ on:
       - '.github/*.yml'
 
 jobs:
-  publish-image-k9:
-    name: Build på nytt for publisering til k9saksbehandling i GAR
-    if: github.ref_name == 'master'
+  build-app:
+    name: Build
     permissions:
       contents: read
       packages: write
       id-token: write
-      pull-requests: read
-    uses: navikt/fp-gha-workflows/.github/workflows/build-app-no-db.yml@main
+    uses: navikt/sif-gha-workflows/.github/workflows/maven-build-app-db.yml@main
     with:
-      build-image: ${{ github.ref_name == 'master' }} # default: true
-      push-image: ${{ github.ref_name == 'master' }} # default: false
-      namespace: k9saksbehandling
-      sonar-scan: false
+      java-version: 21
+      build-image: ${{ github.actor != 'dependabot[bot]' }}
+      push-image: ${{ github.ref_name == github.event.repository.default_branch}}
+      upload-image: ${{ github.ref_name != github.event.repository.default_branch }} # TODO: hør med Qadeer om denne trengs
+      db_schema: k9inntektsmelding_unit
     secrets: inherit
 
-  deploy-dev-k9saksbehandling:
+  verdikjede-tester:
+    name: Verdikjedetester
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
+    uses: navikt/sif-gha-workflows/.github/workflows/verdikjede-test-v2.yml@main
+    if: ${{github.actor != 'dependabot[bot]'}}
+    needs: build-app
+    with:
+      tag: ${{ needs.build-app.outputs.build-version }}
+      suites: "pleiepenger,livetssluttfase"
+      override_image_artifact_name: ${{ github.ref_name != github.event.repository.default_branch && needs.build-app.outputs.image-artifact-name || null }}
+      image_version: ${{ needs.build-app.outputs.build-version }}
+
+  deploy-dev:
     name: Deploy dev
     permissions:
       id-token: write
-    if: github.ref_name == 'master'
-    needs: [publish-image-k9]
+    if: |
+      github.ref_name == 'master'
+        && always()
+        && needs.verdikjede-tester.outputs.pleiepenger == 'success'
+        && needs.verdikjede-tester.outputs.livetssluttfase == 'success'
+    needs: [ build-app, verdikjede-tester ]
     uses: navikt/ft-inntektsmelding/.github/workflows/deploy.yml@master
     with:
-      image: ${{ needs.publish-image-k9.outputs.build-version }}
+      image: ${{ needs.build-app.outputs.build-version }}
       cluster: dev-gcp
       namespace: k9saksbehandling
     secrets: inherit
 
-#  deploy-prod:
-#    name: Deploy prod
-#    permissions:
-#      id-token: write
-#    if: github.ref_name == 'master'
-#    needs: [build-app]
-#    uses: navikt/fp-gha-workflows/.github/workflows/deploy.yml@main
-#    with:
-#      gar: true
-#      image: ${{ needs.build-app.outputs.build-version }}
-#      cluster: prod-gcp
-#    secrets: inherit
-
-
-
+  deploy-prod:
+    name: Deploy prod
+    permissions:
+      id-token: write
+    if: github.ref_name == 'master'
+    needs: [ build-app, verdikjede-tester, deploy-dev ]
+    uses: navikt/ft-inntektsmelding/.github/workflows/deploy.yml@master
+    with:
+      image: ${{ needs.build-app.outputs.build-version }}
+      cluster: prod-gcp
+      namespace: k9saksbehandling
+    secrets: inherit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,5 +15,7 @@ jobs:
      actions: read
      contents: read
      security-events: write
-   uses: navikt/fp-gha-workflows/.github/workflows/codeql.yml@main
+   uses: navikt/sif-gha-workflows/.github/workflows/codeql.yml@main
    secrets: inherit
+   with:
+     java-version: 21

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -12,5 +12,5 @@ jobs:
   deps:
     permissions:
       contents: write
-    uses: navikt/fp-gha-workflows/.github/workflows/mvn-dependency-submission.yml@main
+    uses: navikt/sif-gha-workflows/.github/workflows/maven-dependency-submission.yml@main
     secrets: inherit


### PR DESCRIPTION
**Endringer**
* Buker k9 sin workflow for å bygg, codeql og dependency-submission.
* Bruker foreløpig ft-inntektsmelding sin workflow for deploy. 
* Legger til ny jobb for deploy til prod.

**Videre**
* I neste iterasjon ønsker vi å erstatte workflow for deploy med k9 sin reuseable workflow. 