### PR TITLE
Returner inntektsinfo på samme format som for vanlige inntektsmeldinger

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/HentInntektsopplysningerResponseDto.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/HentInntektsopplysningerResponseDto.java
@@ -1,0 +1,15 @@
+package no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+import no.nav.familie.inntektsmelding.typer.dto.MånedslønnStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+public record HentInntektsopplysningerResponseDto(@Valid BigDecimal gjennomsnittLønn, @NotNull @Valid List<MånedsinntektDto> månedsinntekter) {
+    public record MånedsinntektDto(@NotNull LocalDate fom, @NotNull LocalDate tom, BigDecimal beløp, @Valid @NotNull MånedslønnStatus status) {
+    }
+}

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRestTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRestTest.java
@@ -80,10 +80,14 @@ class RefusjonOmsorgsdagerRestTest {
         var organisasjonsnummer = "999999999";
         var skjæringstidspunkt = LocalDate.parse("2025-01-01");
 
-        var inntektsopplysninger = new Inntektsopplysninger(
+        var inntektsopplysninger = new HentInntektsopplysningerResponseDto(
             new BigDecimal(100000),
-            organisasjonsnummer,
-            List.of(new Inntektsopplysninger.InntektMåned(new BigDecimal(100000), YearMonth.of(2025, 1), MånedslønnStatus.BRUKT_I_GJENNOMSNITT))
+            List.of(new HentInntektsopplysningerResponseDto.MånedsinntektDto(
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2025, 2, 1),
+                new BigDecimal(100000),
+                MånedslønnStatus.BRUKT_I_GJENNOMSNITT
+            ))
         );
         when(refusjonOmsorgsdagerServiceMock.hentInntektsopplysninger(personIdent, organisasjonsnummer, skjæringstidspunkt)).thenReturn(inntektsopplysninger);
 

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerServiceTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerServiceTest.java
@@ -10,6 +10,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
+import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.HentInntektsopplysningerResponseDto;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -113,7 +114,7 @@ class RefusjonOmsorgsdagerServiceTest {
 
         var response = service.hentInntektsopplysninger(fødselsnummer, "999999999", LocalDate.now());
 
-        assertEquals(new Inntektsopplysninger(new BigDecimal(10000), organisasjonsnummer, List.of()), response);
+        assertEquals(new HentInntektsopplysningerResponseDto(new BigDecimal(10000), List.of()), response);
     }
 
     @Test


### PR DESCRIPTION
Under testing av innhenting av inntektsinformasjon, så la jeg merke til at inntektsmeldinger gjør litt hokus pokus med inntektsinformasjonen, som vi ikke gjør i refusjonsflyten. 

Denne PRen aligner disse to, slik at det blir likt (og at vi dermed kan bruke samme komponent på frontenden).