### PR TITLE
Fiks: Håndter innetekstmelding for omsorgspenger gjennom "vanlig flyt"

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/K9DokgenTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/dokgen/K9DokgenTjeneste.java
@@ -44,7 +44,7 @@ public class K9DokgenTjeneste {
         personInfo = personTjeneste.hentPersonInfoFraAktørId(inntektsmelding.getAktørId(), inntektsmelding.getYtelsetype());
         arbeidsgiverNavn = finnArbeidsgiverNavn(inntektsmelding, arbeidsgvierIdent);
 
-        if (inntektsmelding.getYtelsetype() == Ytelsetype.OMSORGSPENGER) {
+        if (inntektsmelding.getYtelsetype() == Ytelsetype.OMSORGSPENGER && inntektsmelding.getOmsorgspenger() != null) {
             var omsorgspengerRefusjonPdfData = OmsorgspengerRefusjonPdfDataMapper.mapOmsorgspengerRefusjonData(inntektsmelding, arbeidsgiverNavn, personInfo, arbeidsgvierIdent);
             return genererPdfForOmsorgspengerRefusjon(omsorgspengerRefusjonPdfData, inntektsmeldingsid);
         }


### PR DESCRIPTION
### **Behov / Bakgrunn**
Dersom bruker søker om omsorgspenger og arbeidsgiver skal sende en inntektsmelding, skal ikke arbeidsgiver sende med perioder. K9-sak skal bruke oppgitte perioder fra søker.

### **Løsning**
Legg til sjekk for om `Omsorgspenger`-feltet er satt.