### PR TITLE
Chore: Skiller ut metoder for innhenting av opplysninger fra InntektsmeldingTjeneste til Grunnlagtjeneste

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
@@ -15,7 +15,7 @@ import jakarta.ws.rs.core.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import no.nav.familie.inntektsmelding.imdialog.tjenester.InntektsmeldingTjeneste;
+import no.nav.familie.inntektsmelding.imdialog.tjenester.GrunnlagTjeneste;
 import no.nav.familie.inntektsmelding.server.auth.api.AutentisertMedTokenX;
 import no.nav.familie.inntektsmelding.server.auth.api.Tilgangskontrollert;
 import no.nav.foreldrepenger.konfig.Environment;
@@ -32,7 +32,7 @@ public class ArbeidsgiverinitiertDialogRest {
     private static final String HENT_ARBEIDSFORHOLD = "/arbeidsforhold";
     private static final String HENT_OPPLYSNINGER = "/opplysninger";
 
-    private InntektsmeldingTjeneste inntektsmeldingTjeneste;
+    private GrunnlagTjeneste grunnlagTjeneste;
     private boolean erProd = true;
 
     ArbeidsgiverinitiertDialogRest() {
@@ -40,8 +40,8 @@ public class ArbeidsgiverinitiertDialogRest {
     }
 
     @Inject
-    public ArbeidsgiverinitiertDialogRest(InntektsmeldingTjeneste inntektsmeldingTjeneste) {
-        this.inntektsmeldingTjeneste = inntektsmeldingTjeneste;
+    public ArbeidsgiverinitiertDialogRest(GrunnlagTjeneste grunnlagTjeneste) {
+        this.grunnlagTjeneste = grunnlagTjeneste;
         this.erProd = Environment.current().isProd();
     }
 
@@ -54,7 +54,7 @@ public class ArbeidsgiverinitiertDialogRest {
             throw new IllegalStateException("Ugyldig kall på restpunkt som ikke er lansert");
         }
         LOG.info("Henter arbeidsforhold for søker");
-        var response = inntektsmeldingTjeneste.finnArbeidsforholdForFnr(request.fødselsnummer(), request.ytelseType(), request.førsteFraværsdag());
+        var response = grunnlagTjeneste.finnArbeidsforholdForFnr(request.fødselsnummer(), request.ytelseType(), request.førsteFraværsdag());
         return response.map(d ->Response.ok(d).build()).orElseGet(() -> Response.status(Response.Status.NOT_FOUND).build());
     }
 
@@ -67,7 +67,7 @@ public class ArbeidsgiverinitiertDialogRest {
             throw new IllegalStateException("Ugyldig kall på restpunkt som ikke er lansert");
         }
         LOG.info("Henter opplysninger for søker");
-        var hentOpplysningerResponse = inntektsmeldingTjeneste.hentOpplysninger(request.fødselsnummer(), request.ytelseType(), request.førsteFraværsdag(), request.organisasjonsnummer());
+        var hentOpplysningerResponse = grunnlagTjeneste.hentOpplysninger(request.fødselsnummer(), request.ytelseType(), request.førsteFraværsdag(), request.organisasjonsnummer());
         return Response.ok(hentOpplysningerResponse).build();
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/InntektsmeldingDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/InntektsmeldingDialogRest.java
@@ -21,6 +21,7 @@ import jakarta.ws.rs.core.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import no.nav.familie.inntektsmelding.imdialog.tjenester.GrunnlagTjeneste;
 import no.nav.familie.inntektsmelding.imdialog.tjenester.InntektsmeldingMottakTjeneste;
 import no.nav.familie.inntektsmelding.imdialog.tjenester.InntektsmeldingTjeneste;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
@@ -48,6 +49,7 @@ public class InntektsmeldingDialogRest {
 
     private InntektsmeldingTjeneste inntektsmeldingTjeneste;
     private InntektsmeldingMottakTjeneste inntektsmeldingMottakTjeneste;
+    private GrunnlagTjeneste grunnlagTjeneste;
     private Tilgang tilgang;
 
     InntektsmeldingDialogRest() {
@@ -57,9 +59,11 @@ public class InntektsmeldingDialogRest {
     @Inject
     public InntektsmeldingDialogRest(InntektsmeldingTjeneste inntektsmeldingTjeneste,
                                      InntektsmeldingMottakTjeneste inntektsmeldingMottakTjeneste,
+                                     GrunnlagTjeneste grunnlagTjeneste,
                                      Tilgang tilgang) {
         this.inntektsmeldingTjeneste = inntektsmeldingTjeneste;
         this.inntektsmeldingMottakTjeneste = inntektsmeldingMottakTjeneste;
+        this.grunnlagTjeneste = grunnlagTjeneste;
         this.tilgang = tilgang;
     }
 
@@ -71,7 +75,7 @@ public class InntektsmeldingDialogRest {
         tilgang.sjekkAtArbeidsgiverHarTilgangTilBedrift(forespørselUuid);
 
         LOG.info("Henter forespørsel med uuid {}", forespørselUuid);
-        var dto = inntektsmeldingTjeneste.hentOpplysninger(forespørselUuid);
+        var dto = grunnlagTjeneste.hentOpplysninger(forespørselUuid);
         return Response.ok(dto).build();
 
     }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
@@ -1,0 +1,182 @@
+package no.nav.familie.inntektsmelding.imdialog.tjenester;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
+import no.nav.familie.inntektsmelding.imdialog.rest.HentOpplysningerResponse;
+import no.nav.familie.inntektsmelding.imdialog.rest.SlåOppArbeidstakerResponseDto;
+import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.InntektTjeneste;
+import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.OrganisasjonTjeneste;
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
+import no.nav.familie.inntektsmelding.koder.ForespørselStatus;
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.familie.inntektsmelding.refusjonomsorgsdager.tjenester.ArbeidstakerTjeneste;
+import no.nav.familie.inntektsmelding.typer.dto.InnsenderDto;
+import no.nav.familie.inntektsmelding.typer.dto.InntektsopplysningerDto;
+import no.nav.familie.inntektsmelding.typer.dto.KodeverkMapper;
+import no.nav.familie.inntektsmelding.typer.dto.MånedsinntektDto;
+import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonInfoDto;
+import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
+import no.nav.familie.inntektsmelding.typer.dto.PersonInfoDto;
+import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
+import no.nav.vedtak.sikkerhet.kontekst.IdentType;
+import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
+
+@ApplicationScoped
+public class GrunnlagTjeneste {
+    private static final Logger LOG = LoggerFactory.getLogger(GrunnlagTjeneste.class);
+    private ForespørselBehandlingTjeneste forespørselBehandlingTjeneste;
+    private PersonTjeneste personTjeneste;
+    private OrganisasjonTjeneste organisasjonTjeneste;
+    private InntektTjeneste inntektTjeneste;
+    private ArbeidstakerTjeneste arbeidstakerTjeneste;
+
+    GrunnlagTjeneste() {
+    }
+
+    @Inject
+    public GrunnlagTjeneste(ForespørselBehandlingTjeneste forespørselBehandlingTjeneste,
+                            PersonTjeneste personTjeneste,
+                            OrganisasjonTjeneste organisasjonTjeneste,
+                            InntektTjeneste inntektTjeneste,
+                            ArbeidstakerTjeneste arbeidstakerTjeneste) {
+        this.forespørselBehandlingTjeneste = forespørselBehandlingTjeneste;
+        this.personTjeneste = personTjeneste;
+        this.organisasjonTjeneste = organisasjonTjeneste;
+        this.inntektTjeneste = inntektTjeneste;
+        this.arbeidstakerTjeneste = arbeidstakerTjeneste;
+    }
+
+    public HentOpplysningerResponse hentOpplysninger(UUID forespørselUuid) {
+        var forespørsel = forespørselBehandlingTjeneste.hentForespørsel(forespørselUuid)
+            .orElseThrow(() -> new IllegalStateException(
+                "Prøver å hente data for en forespørsel som ikke finnes, forespørselUUID: " + forespørselUuid));
+        var personInfo = finnPerson(forespørsel.getAktørId());
+        var organisasjonInfo = finnOrganisasjonInfo(forespørsel.getOrganisasjonsnummer());
+        var innsender = finnInnsender();
+        var inntektsopplysninger = finnInntektsopplysninger(forespørsel.getUuid(),
+            forespørsel.getAktørId(),
+            forespørsel.getSkjæringstidspunkt(),
+            forespørsel.getOrganisasjonsnummer());
+
+        return new HentOpplysningerResponse(personInfo,
+            organisasjonInfo,
+            innsender,
+            inntektsopplysninger,
+            forespørsel.getSkjæringstidspunkt(),
+            KodeverkMapper.mapYtelsetype(forespørsel.getYtelseType()),
+            forespørsel.getUuid(),
+            KodeverkMapper.mapForespørselStatus(forespørsel.getStatus()),
+            forespørsel.getFørsteUttaksdato().orElseGet(forespørsel::getSkjæringstidspunkt),
+            forespørsel.getEtterspurtePerioder());
+    }
+
+    public HentOpplysningerResponse hentOpplysninger(PersonIdent fødselsnummer,
+                                                     Ytelsetype ytelsetype,
+                                                     LocalDate førsteFraværsdag,
+                                                     OrganisasjonsnummerDto organisasjonsnummer) {
+        var personInfo = personTjeneste.hentPersonFraIdent(fødselsnummer);
+
+        var eksisterendeForepørsler = forespørselBehandlingTjeneste.finnForespørslerUnderBehandling(personInfo.aktørId(),
+            ytelsetype,
+            organisasjonsnummer.orgnr());
+        var forespørslerSomMatcherFraværsdag = eksisterendeForepørsler.stream()
+            .filter(f -> førsteFraværsdag.equals(f.getFørsteUttaksdato()
+                .orElse(f.getSkjæringstidspunkt()))) // TODO: sjekk for et større intervall etterhvert
+            .toList();
+
+        if (!forespørslerSomMatcherFraværsdag.isEmpty()) {
+            var forespørsel = forespørslerSomMatcherFraværsdag.getFirst();
+            return hentOpplysninger(forespørsel.getUuid());
+        }
+
+        var personDto = new PersonInfoDto(personInfo.fornavn(), personInfo.mellomnavn(), personInfo.etternavn(), personInfo.fødselsnummer().getIdent(), personInfo.aktørId().getAktørId());
+        var organisasjonInfo = finnOrganisasjonInfo(organisasjonsnummer.orgnr());
+        var innsender = finnInnsender();
+        var inntektsopplysninger = finnInntektsopplysninger(null, personInfo.aktørId(), førsteFraværsdag, organisasjonsnummer.orgnr());
+        return new HentOpplysningerResponse(personDto,
+            organisasjonInfo,
+            innsender,
+            inntektsopplysninger,
+            førsteFraværsdag,
+            KodeverkMapper.mapYtelsetype(ytelsetype),
+            null,
+            KodeverkMapper.mapForespørselStatus(ForespørselStatus.UNDER_BEHANDLING),
+            førsteFraværsdag,
+            null
+        );
+    }
+
+    private InnsenderDto finnInnsender() {
+        if (!KontekstHolder.harKontekst() || !IdentType.EksternBruker.equals(KontekstHolder.getKontekst().getIdentType())) {
+            throw new IllegalStateException("Mangler innlogget bruker kontekst.");
+        }
+        var pid = KontekstHolder.getKontekst().getUid();
+        var personInfo = personTjeneste.hentPersonFraIdent(PersonIdent.fra(pid));
+        return new InnsenderDto(personInfo.fornavn(), personInfo.mellomnavn(), personInfo.etternavn(),
+            personInfo.telefonnummer());
+    }
+
+    private InntektsopplysningerDto finnInntektsopplysninger(UUID uuid,
+                                                             AktørIdEntitet aktørId,
+                                                             LocalDate skjæringstidspunkt,
+                                                             String organisasjonsnummer) {
+        var inntektsopplysninger = inntektTjeneste.hentInntekt(aktørId, skjæringstidspunkt, LocalDate.now(),
+            organisasjonsnummer);
+        if (uuid == null) {
+            LOG.info("Inntektsopplysninger for aktørId {} var {}", aktørId, inntektsopplysninger);
+        } else {
+            LOG.info("Inntektsopplysninger for forespørsel {} var {}", uuid, inntektsopplysninger);
+        }
+        var inntekter = inntektsopplysninger.måneder()
+            .stream()
+            .map(i -> new MånedsinntektDto(i.månedÅr().atDay(1),
+                i.månedÅr().atEndOfMonth(),
+                i.beløp(),
+                i.status()))
+            .toList();
+        return new InntektsopplysningerDto(inntektsopplysninger.gjennomsnitt(), inntekter);
+    }
+
+    private OrganisasjonInfoDto finnOrganisasjonInfo(String organisasjonsnummer) {
+        var orgdata = organisasjonTjeneste.finnOrganisasjon(organisasjonsnummer);
+        return new OrganisasjonInfoDto(orgdata.navn(), orgdata.orgnr());
+    }
+
+    private PersonInfoDto finnPerson(AktørIdEntitet aktørId) {
+        var personInfo = personTjeneste.hentPersonInfoFraAktørId(aktørId);
+        return new PersonInfoDto(personInfo.fornavn(), personInfo.mellomnavn(), personInfo.etternavn(),
+            personInfo.fødselsnummer().getIdent(), personInfo.aktørId().getAktørId());
+    }
+
+    public Optional<SlåOppArbeidstakerResponseDto> finnArbeidsforholdForFnr(PersonIdent fødselsnummer, Ytelsetype ytelsetype,
+                                                                            LocalDate førsteFraværsdag) {
+        // TODO Skal vi sjekke noe mtp kode 6/7
+        var personInfo = personTjeneste.hentPersonFraIdent(fødselsnummer);
+        if (personInfo == null) {
+            return Optional.empty();
+        }
+        var arbeidsforholdBrukerHarTilgangTil = arbeidstakerTjeneste.finnArbeidsforholdInnsenderHarTilgangTil(fødselsnummer, førsteFraværsdag);
+        if (arbeidsforholdBrukerHarTilgangTil.isEmpty()) {
+            return Optional.empty();
+        }
+        var arbeidsforholdDto = arbeidsforholdBrukerHarTilgangTil.stream()
+            .map(a -> new SlåOppArbeidstakerResponseDto.ArbeidsforholdDto(organisasjonTjeneste.finnOrganisasjon(a.organisasjonsnummer()).navn(),
+                a.organisasjonsnummer()))
+            .collect(Collectors.toSet());
+        return Optional.of(new SlåOppArbeidstakerResponseDto(personInfo.fornavn(),
+            personInfo.mellomnavn(),
+            personInfo.etternavn(),
+            arbeidsforholdDto));
+    }
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingTjeneste.java
@@ -1,10 +1,7 @@
 package no.nav.familie.inntektsmelding.imdialog.tjenester;
 
-import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -15,38 +12,17 @@ import org.slf4j.LoggerFactory;
 import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
 import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingEntitet;
 import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingRepository;
-import no.nav.familie.inntektsmelding.imdialog.rest.HentOpplysningerResponse;
 import no.nav.familie.inntektsmelding.imdialog.rest.InntektsmeldingResponseDto;
-import no.nav.familie.inntektsmelding.imdialog.rest.SlåOppArbeidstakerResponseDto;
 import no.nav.familie.inntektsmelding.integrasjoner.dokgen.K9DokgenTjeneste;
-import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.InntektTjeneste;
-import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.OrganisasjonTjeneste;
-import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
-import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
-import no.nav.familie.inntektsmelding.koder.ForespørselStatus;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
-import no.nav.familie.inntektsmelding.refusjonomsorgsdager.tjenester.ArbeidstakerTjeneste;
-import no.nav.familie.inntektsmelding.typer.dto.InnsenderDto;
-import no.nav.familie.inntektsmelding.typer.dto.InntektsopplysningerDto;
-import no.nav.familie.inntektsmelding.typer.dto.KodeverkMapper;
-import no.nav.familie.inntektsmelding.typer.dto.MånedsinntektDto;
-import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonInfoDto;
-import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
-import no.nav.familie.inntektsmelding.typer.dto.PersonInfoDto;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
-import no.nav.vedtak.sikkerhet.kontekst.IdentType;
-import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
 
 @ApplicationScoped
 public class InntektsmeldingTjeneste {
     private static final Logger LOG = LoggerFactory.getLogger(InntektsmeldingTjeneste.class);
     private ForespørselBehandlingTjeneste forespørselBehandlingTjeneste;
     private InntektsmeldingRepository inntektsmeldingRepository;
-    private PersonTjeneste personTjeneste;
-    private OrganisasjonTjeneste organisasjonTjeneste;
-    private InntektTjeneste inntektTjeneste;
     private K9DokgenTjeneste k9DokgenTjeneste;
-    private ArbeidstakerTjeneste arbeidstakerTjeneste;
 
     InntektsmeldingTjeneste() {
     }
@@ -54,78 +30,10 @@ public class InntektsmeldingTjeneste {
     @Inject
     public InntektsmeldingTjeneste(ForespørselBehandlingTjeneste forespørselBehandlingTjeneste,
                                    InntektsmeldingRepository inntektsmeldingRepository,
-                                   PersonTjeneste personTjeneste,
-                                   OrganisasjonTjeneste organisasjonTjeneste,
-                                   InntektTjeneste inntektTjeneste,
-                                   K9DokgenTjeneste k9DokgenTjeneste,
-                                   ArbeidstakerTjeneste arbeidstakerTjeneste) {
+                                   K9DokgenTjeneste k9DokgenTjeneste) {
         this.forespørselBehandlingTjeneste = forespørselBehandlingTjeneste;
         this.inntektsmeldingRepository = inntektsmeldingRepository;
-        this.personTjeneste = personTjeneste;
-        this.organisasjonTjeneste = organisasjonTjeneste;
-        this.inntektTjeneste = inntektTjeneste;
         this.k9DokgenTjeneste = k9DokgenTjeneste;
-        this.arbeidstakerTjeneste = arbeidstakerTjeneste;
-    }
-
-    public HentOpplysningerResponse hentOpplysninger(UUID forespørselUuid) {
-        var forespørsel = forespørselBehandlingTjeneste.hentForespørsel(forespørselUuid)
-            .orElseThrow(() -> new IllegalStateException(
-                "Prøver å hente data for en forespørsel som ikke finnes, forespørselUUID: " + forespørselUuid));
-        var personInfo = finnPerson(forespørsel.getAktørId());
-        var organisasjonInfo = finnOrganisasjonInfo(forespørsel.getOrganisasjonsnummer());
-        var innsender = finnInnsender();
-        var inntektsopplysninger = finnInntektsopplysninger(forespørsel.getUuid(),
-            forespørsel.getAktørId(),
-            forespørsel.getSkjæringstidspunkt(),
-            forespørsel.getOrganisasjonsnummer());
-
-        return new HentOpplysningerResponse(personInfo,
-            organisasjonInfo,
-            innsender,
-            inntektsopplysninger,
-            forespørsel.getSkjæringstidspunkt(),
-            KodeverkMapper.mapYtelsetype(forespørsel.getYtelseType()),
-            forespørsel.getUuid(),
-            KodeverkMapper.mapForespørselStatus(forespørsel.getStatus()),
-            forespørsel.getFørsteUttaksdato().orElseGet(forespørsel::getSkjæringstidspunkt),
-            forespørsel.getEtterspurtePerioder());
-    }
-
-    public HentOpplysningerResponse hentOpplysninger(PersonIdent fødselsnummer,
-                                                     Ytelsetype ytelsetype,
-                                                     LocalDate førsteFraværsdag,
-                                                     OrganisasjonsnummerDto organisasjonsnummer) {
-        var personInfo = personTjeneste.hentPersonFraIdent(fødselsnummer);
-
-        var eksisterendeForepørsler = forespørselBehandlingTjeneste.finnForespørslerUnderBehandling(personInfo.aktørId(),
-            ytelsetype,
-            organisasjonsnummer.orgnr());
-        var forespørslerSomMatcherFraværsdag = eksisterendeForepørsler.stream()
-            .filter(f -> førsteFraværsdag.equals(f.getFørsteUttaksdato()
-                .orElse(f.getSkjæringstidspunkt()))) // TODO: sjekk for et større intervall etterhvert
-            .toList();
-
-        if (!forespørslerSomMatcherFraværsdag.isEmpty()) {
-            var forespørsel = forespørslerSomMatcherFraværsdag.getFirst();
-            return hentOpplysninger(forespørsel.getUuid());
-        }
-
-        var personDto = new PersonInfoDto(personInfo.fornavn(), personInfo.mellomnavn(), personInfo.etternavn(), personInfo.fødselsnummer().getIdent(), personInfo.aktørId().getAktørId());
-        var organisasjonInfo = finnOrganisasjonInfo(organisasjonsnummer.orgnr());
-        var innsender = finnInnsender();
-        var inntektsopplysninger = finnInntektsopplysninger(null, personInfo.aktørId(), førsteFraværsdag, organisasjonsnummer.orgnr());
-        return new HentOpplysningerResponse(personDto,
-            organisasjonInfo,
-            innsender,
-            inntektsopplysninger,
-            førsteFraværsdag,
-            KodeverkMapper.mapYtelsetype(ytelsetype),
-            null,
-            KodeverkMapper.mapForespørselStatus(ForespørselStatus.UNDER_BEHANDLING),
-            førsteFraværsdag,
-            null
-        );
     }
 
     public InntektsmeldingEntitet hentInntektsmelding(long inntektsmeldingId) {
@@ -173,68 +81,5 @@ public class InntektsmeldingTjeneste {
     public byte[] hentPDF(long id) {
         var inntektsmeldingEntitet = inntektsmeldingRepository.hentInntektsmelding(id);
         return k9DokgenTjeneste.mapDataOgGenererPdf(inntektsmeldingEntitet);
-    }
-
-    private InnsenderDto finnInnsender() {
-        if (!KontekstHolder.harKontekst() || !IdentType.EksternBruker.equals(KontekstHolder.getKontekst().getIdentType())) {
-            throw new IllegalStateException("Mangler innlogget bruker kontekst.");
-        }
-        var pid = KontekstHolder.getKontekst().getUid();
-        var personInfo = personTjeneste.hentPersonFraIdent(PersonIdent.fra(pid));
-        return new InnsenderDto(personInfo.fornavn(), personInfo.mellomnavn(), personInfo.etternavn(),
-            personInfo.telefonnummer());
-    }
-
-    private InntektsopplysningerDto finnInntektsopplysninger(UUID uuid,
-                                                             AktørIdEntitet aktørId,
-                                                             LocalDate skjæringstidspunkt,
-                                                             String organisasjonsnummer) {
-        var inntektsopplysninger = inntektTjeneste.hentInntekt(aktørId, skjæringstidspunkt, LocalDate.now(),
-            organisasjonsnummer);
-        if (uuid == null) {
-            LOG.info("Inntektsopplysninger for aktørId {} var {}", aktørId, inntektsopplysninger);
-        } else {
-            LOG.info("Inntektsopplysninger for forespørsel {} var {}", uuid, inntektsopplysninger);
-        }
-        var inntekter = inntektsopplysninger.måneder()
-            .stream()
-            .map(i -> new MånedsinntektDto(i.månedÅr().atDay(1),
-                i.månedÅr().atEndOfMonth(),
-                i.beløp(),
-                i.status()))
-            .toList();
-        return new InntektsopplysningerDto(inntektsopplysninger.gjennomsnitt(), inntekter);
-    }
-
-    private OrganisasjonInfoDto finnOrganisasjonInfo(String organisasjonsnummer) {
-        var orgdata = organisasjonTjeneste.finnOrganisasjon(organisasjonsnummer);
-        return new OrganisasjonInfoDto(orgdata.navn(), orgdata.orgnr());
-    }
-
-    private PersonInfoDto finnPerson(AktørIdEntitet aktørId) {
-        var personInfo = personTjeneste.hentPersonInfoFraAktørId(aktørId);
-        return new PersonInfoDto(personInfo.fornavn(), personInfo.mellomnavn(), personInfo.etternavn(),
-            personInfo.fødselsnummer().getIdent(), personInfo.aktørId().getAktørId());
-    }
-
-    public Optional<SlåOppArbeidstakerResponseDto> finnArbeidsforholdForFnr(PersonIdent fødselsnummer, Ytelsetype ytelsetype,
-                                                                            LocalDate førsteFraværsdag) {
-        // TODO Skal vi sjekke noe mtp kode 6/7
-        var personInfo = personTjeneste.hentPersonFraIdent(fødselsnummer);
-        if (personInfo == null) {
-            return Optional.empty();
-        }
-        var arbeidsforholdBrukerHarTilgangTil = arbeidstakerTjeneste.finnArbeidsforholdInnsenderHarTilgangTil(fødselsnummer, førsteFraværsdag);
-        if (arbeidsforholdBrukerHarTilgangTil.isEmpty()) {
-            return Optional.empty();
-        }
-        var arbeidsforholdDto = arbeidsforholdBrukerHarTilgangTil.stream()
-            .map(a -> new SlåOppArbeidstakerResponseDto.ArbeidsforholdDto(organisasjonTjeneste.finnOrganisasjon(a.organisasjonsnummer()).navn(),
-                a.organisasjonsnummer()))
-            .collect(Collectors.toSet());
-        return Optional.of(new SlåOppArbeidstakerResponseDto(personInfo.fornavn(),
-            personInfo.mellomnavn(),
-            personInfo.etternavn(),
-            arbeidsforholdDto));
     }
 }

--- a/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjenesteTest.java
@@ -21,8 +21,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselMapper;
 import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
-import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingRepository;
-import no.nav.familie.inntektsmelding.integrasjoner.dokgen.K9DokgenTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.InntektTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.Inntektsopplysninger;
 import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.Organisasjon;
@@ -46,14 +44,12 @@ import no.nav.vedtak.sikkerhet.oidc.token.OpenIDToken;
 import no.nav.vedtak.sikkerhet.oidc.token.TokenString;
 
 @ExtendWith(MockitoExtension.class)
-class InntektsmeldingTjenesteTest {
+class GrunnlagTjenesteTest {
 
     private static final String INNMELDER_UID = "12324312345";
 
     @Mock
     private ForespørselBehandlingTjeneste forespørselBehandlingTjeneste;
-    @Mock
-    private InntektsmeldingRepository inntektsmeldingRepository;
     @Mock
     private PersonTjeneste personTjeneste;
     @Mock
@@ -61,11 +57,9 @@ class InntektsmeldingTjenesteTest {
     @Mock
     private InntektTjeneste inntektTjeneste;
     @Mock
-    private K9DokgenTjeneste k9DokgenTjeneste;
-    @Mock
     private ArbeidstakerTjeneste arbeidstakerTjeneste;
 
-    private InntektsmeldingTjeneste inntektsmeldingTjeneste;
+    private GrunnlagTjeneste grunnlagTjeneste;
 
     @BeforeAll
     static void beforeAll() {
@@ -80,12 +74,11 @@ class InntektsmeldingTjenesteTest {
 
     @BeforeEach
     void setUp() {
-        inntektsmeldingTjeneste = new InntektsmeldingTjeneste(forespørselBehandlingTjeneste, inntektsmeldingRepository, personTjeneste,
-            organisasjonTjeneste, inntektTjeneste, k9DokgenTjeneste, arbeidstakerTjeneste);
+        grunnlagTjeneste = new GrunnlagTjeneste(forespørselBehandlingTjeneste, personTjeneste, organisasjonTjeneste, inntektTjeneste, arbeidstakerTjeneste);
     }
 
     @Test
-    void skal_lage_dto() {
+    void skal_hente_opplysninger() {
         // Arrange
         var uuid = UUID.randomUUID();
         var forespørsel = ForespørselMapper.mapForespørsel("999999999",
@@ -114,7 +107,7 @@ class InntektsmeldingTjenesteTest {
             List.of(inntekt1, inntekt2, inntekt3)));
 
         // Act
-        var imDialogDto = inntektsmeldingTjeneste.hentOpplysninger(uuid);
+        var imDialogDto = grunnlagTjeneste.hentOpplysninger(uuid);
 
         // Assert
         assertThat(imDialogDto.skjæringstidspunkt()).isEqualTo(forespørsel.getSkjæringstidspunkt());
@@ -154,7 +147,7 @@ class InntektsmeldingTjenesteTest {
     }
 
     @Test
-    void skal_lage_dto_med_første_uttaksdato() {
+    void skal_hente_opplysninger_med_første_uttaksdato() {
         // Arrange
         var uuid = UUID.randomUUID();
         var forespørsel = ForespørselMapper.mapForespørsel("999999999",
@@ -180,7 +173,7 @@ class InntektsmeldingTjenesteTest {
             List.of()));
 
         // Act
-        var imDialogDto = inntektsmeldingTjeneste.hentOpplysninger(uuid);
+        var imDialogDto = grunnlagTjeneste.hentOpplysninger(uuid);
 
         // Assert
         assertThat(imDialogDto.skjæringstidspunkt()).isEqualTo(forespørsel.getSkjæringstidspunkt());
@@ -214,7 +207,7 @@ class InntektsmeldingTjenesteTest {
             "ARB-001")));
         when(organisasjonTjeneste.finnOrganisasjon(orgnr)).thenReturn(new Organisasjon("Bedriften", orgnr));
         // Act
-        var response = inntektsmeldingTjeneste.finnArbeidsforholdForFnr(fnr, Ytelsetype.PLEIEPENGER_SYKT_BARN, LocalDate.now()).orElse(null);
+        var response = grunnlagTjeneste.finnArbeidsforholdForFnr(fnr, Ytelsetype.PLEIEPENGER_SYKT_BARN, LocalDate.now()).orElse(null);
 
         // Assert
         assertThat(response).isNotNull();
@@ -252,7 +245,7 @@ class InntektsmeldingTjenesteTest {
             LocalDate.now(),
             organisasjonsnummer.orgnr())).thenReturn(new Inntektsopplysninger(BigDecimal.valueOf(52000), organisasjonsnummer.orgnr(), List.of()));
         // Act
-        var imDialogDto = inntektsmeldingTjeneste.hentOpplysninger(fødselsnummer,
+        var imDialogDto = grunnlagTjeneste.hentOpplysninger(fødselsnummer,
             ytelsetype,
             førsteFraværsdag,
             organisasjonsnummer);
@@ -291,7 +284,7 @@ class InntektsmeldingTjenesteTest {
             LocalDate.now(),
             organisasjonsnummer.orgnr())).thenReturn(new Inntektsopplysninger(BigDecimal.valueOf(52000), organisasjonsnummer.orgnr(), List.of()));
         // Act
-        var imDialogDto = inntektsmeldingTjeneste.hentOpplysninger(fødselsnummer, ytelsetype, førsteFraværsdag, organisasjonsnummer);
+        var imDialogDto = grunnlagTjeneste.hentOpplysninger(fødselsnummer, ytelsetype, førsteFraværsdag, organisasjonsnummer);
 
         // Assert
         assertThat(imDialogDto.person().aktørId()).isEqualTo(aktørId.getAktørId());


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi har behov for å refaktorere koden i InntektsmeldingTjenesten før vi begynner å utvide med ny funksjonalitet for å støtte arbeidsgiver initiert inntektsmelding.

### **Løsning**
Oppretter GrunnlagTjeneste og trekker ut metoder fra InntektsmeldingTjeneste som ikke handler om inntektsmelding
