### PR TITLE
TSFF-2581: Endre validering for endepunkter for omsorgspenger

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRest.java
@@ -90,9 +90,6 @@ public class RefusjonOmsorgsdagerRest {
     ) {
         var inntektsopplysninger = refusjonOmsorgsdagerService.hentInntektsopplysninger(request.fødselsnummer(), request.organisasjonsnummer(), LocalDate.parse(request.skjæringstidspunkt()));
 
-        if (inntektsopplysninger == null) {
-            return Response.status(Response.Status.NOT_FOUND).build();
-        }
         return Response.ok(inntektsopplysninger).build();
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRest.java
@@ -60,9 +60,6 @@ public class RefusjonOmsorgsdagerRest {
         SlåOppArbeidstakerRequest request
     ) {
         var response = refusjonOmsorgsdagerService.hentArbeidstaker(request.fødselsnummer());
-        if (response == null) {
-            return Response.status(Response.Status.NOT_FOUND).build();
-        }
 
         return Response.ok(response).build();
     }

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerService.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerService.java
@@ -21,6 +21,7 @@ import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.ArbeidsforholdDt
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.HentInnloggetBrukerResponse;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.HentInntektsopplysningerResponse;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.SlåOppArbeidstakerResponse;
+import no.nav.vedtak.exception.FunksjonellException;
 
 @ApplicationScoped
 public class RefusjonOmsorgsdagerService {
@@ -50,6 +51,11 @@ public class RefusjonOmsorgsdagerService {
 
     public SlåOppArbeidstakerResponse hentArbeidstaker(PersonIdent fødselsnummer) {
         LOG.info("Slår opp arbeidstaker");
+        var personInfo = personTjeneste.hentPersonFraIdent(fødselsnummer);
+
+        if (personInfo == null) {
+            throw new FunksjonellException("PERSON_IKKE_FUNNET", "Fant ikke person i pdl", null, null);
+        }
 
         var alleArbeidsforhold = arbeidstakerTjeneste.finnArbeidsforholdInnsenderHarTilgangTil(fødselsnummer, LocalDate.now());
         var unikeArbeidsforhold = filtrerUnikeArbeidsforhold(alleArbeidsforhold);
@@ -60,9 +66,8 @@ public class RefusjonOmsorgsdagerService {
             ))
             .toList();
 
-        var personInfo = personTjeneste.hentPersonFraIdent(fødselsnummer);
-        if (arbeidsforholdMedOrgnavn.isEmpty() || personInfo == null) {
-            return null;
+        if (arbeidsforholdMedOrgnavn.isEmpty()) {
+            throw new FunksjonellException("INGEN_ARBEIDSFORHOLD", "Fant ingen arbeidsforhold på brukeren", null, null);
         }
 
         return new SlåOppArbeidstakerResponse(

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerService.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerService.java
@@ -105,15 +105,12 @@ public class RefusjonOmsorgsdagerService {
     public HentInntektsopplysningerResponse hentInntektsopplysninger(PersonIdent fødselsnummer,
                                                                      String organisasjonsnummer,
                                                                      LocalDate skjæringstidspunkt) {
-        var person = personTjeneste.hentPersonFraIdent(fødselsnummer);
-        var arbeidsforhold = arbeidstakerTjeneste.finnArbeidsforholdInnsenderHarTilgangTil(
-            fødselsnummer,
-            skjæringstidspunkt
-        );
-        if (arbeidsforhold.isEmpty() || person == null) {
-            return null;
+        var personInfo = personTjeneste.hentPersonFraIdent(fødselsnummer);
+        if (personInfo == null) {
+            throw new FunksjonellException("PERSON_IKKE_FUNNET", "Fant ikke person i pdl", null, null);
         }
-        var inntekt = inntektTjeneste.hentInntekt(person.aktørId(), skjæringstidspunkt, LocalDate.now(), organisasjonsnummer, Ytelsetype.OMSORGSPENGER);
+
+        var inntekt = inntektTjeneste.hentInntekt(personInfo.aktørId(), skjæringstidspunkt, LocalDate.now(), organisasjonsnummer, Ytelsetype.OMSORGSPENGER);
         var inntekterPerMåned = inntekt.måneder()
             .stream()
             .map(i -> new HentInntektsopplysningerResponse.MånedsinntektDto(i.månedÅr().atDay(1),

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRestTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRestTest.java
@@ -1,7 +1,9 @@
 package no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -21,6 +23,7 @@ import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.tjenester.RefusjonOmsorgsdagerService;
 import no.nav.familie.inntektsmelding.typer.dto.MånedslønnStatus;
+import no.nav.vedtak.exception.FunksjonellException;
 
 @ExtendWith(MockitoExtension.class)
 class RefusjonOmsorgsdagerRestTest {
@@ -51,15 +54,17 @@ class RefusjonOmsorgsdagerRestTest {
     }
 
     @Test
-    void slå_opp_arbeidstaker_skal_returnere_not_found_når_arbeidstaker_ikke_finnes() {
+    void slå_opp_arbeidstaker_kaster_PERSON_IKKE_FUNNET_når_arbeidstaker_ikke_finnes() {
         var fnr = PersonIdent.fra("12345678910");
         var request = new SlåOppArbeidstakerRequest(fnr, Ytelsetype.OMSORGSPENGER);
 
-        when(refusjonOmsorgsdagerServiceMock.hentArbeidstaker(fnr)).thenReturn(null);
+        when(refusjonOmsorgsdagerServiceMock.hentArbeidstaker(fnr))
+            .thenThrow(new FunksjonellException("PERSON_IKKE_FUNNET", "Fant ikke person i pdl", null));
 
-        var response = rest.slåOppArbeidstaker(request);
+        var ex = assertThrows(FunksjonellException.class, () -> rest.slåOppArbeidstaker(request));
 
-        assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+        assertThat(ex.getStatusCode()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+        assertThat(ex.getMessage()).contains("PERSON_IKKE_FUNNET");
     }
 
     @Test

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRestTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRestTest.java
@@ -2,7 +2,6 @@ package no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -101,17 +100,18 @@ class RefusjonOmsorgsdagerRestTest {
     }
 
     @Test
-    void hent_inntektsopplysninger_skal_returnere_not_found_når_servicen_returnerer_null() {
+    void hent_inntektsopplysninger_kaster_PERSON_IKKE_FUNNET_når_person_ikke_finnes() {
         var personIdent = PersonIdent.fra("12345678910");
         var organisasjonsnummer = "999999999";
         var skjæringstidspunkt = LocalDate.parse("2025-01-01");
 
-        when(refusjonOmsorgsdagerServiceMock.hentInntektsopplysninger(personIdent, organisasjonsnummer, skjæringstidspunkt)).thenReturn(null);
+        when(refusjonOmsorgsdagerServiceMock.hentInntektsopplysninger(personIdent, organisasjonsnummer, skjæringstidspunkt))
+            .thenThrow(new FunksjonellException("PERSON_IKKE_FUNNET", "Fant ikke person i pdl", null));
 
-        var response = rest.hentInntektsopplysninger(new HentInntektsopplysningerRequest(personIdent, organisasjonsnummer, "2025-01-01"));
+        var ex = assertThrows(FunksjonellException.class, () -> rest.hentInntektsopplysninger(new HentInntektsopplysningerRequest(personIdent, organisasjonsnummer, "2025-01-01")));
 
-        assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
-        assertNull(response.getEntity());
+        assertThat(ex.getStatusCode()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+        assertThat(ex.getMessage()).contains("PERSON_IKKE_FUNNET");
     }
 
 

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRestTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRestTest.java
@@ -62,7 +62,6 @@ class RefusjonOmsorgsdagerRestTest {
 
         var ex = assertThrows(FunksjonellException.class, () -> rest.slåOppArbeidstaker(request));
 
-        assertThat(ex.getStatusCode()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
         assertThat(ex.getMessage()).contains("PERSON_IKKE_FUNNET");
     }
 
@@ -110,7 +109,6 @@ class RefusjonOmsorgsdagerRestTest {
 
         var ex = assertThrows(FunksjonellException.class, () -> rest.hentInntektsopplysninger(new HentInntektsopplysningerRequest(personIdent, organisasjonsnummer, "2025-01-01")));
 
-        assertThat(ex.getStatusCode()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
         assertThat(ex.getMessage()).contains("PERSON_IKKE_FUNNET");
     }
 

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerServiceTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerServiceTest.java
@@ -2,7 +2,6 @@ package no.nav.familie.inntektsmelding.refusjonomsorgsdager.tjenester;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
@@ -135,7 +134,6 @@ class RefusjonOmsorgsdagerServiceTest {
     void hent_inntektsopplysninger_returnerer_ok() {
         var fødselsnummer = PersonIdent.fra("12345678910");
         var organisasjonsnummer = "999999999";
-        var ansettelsesperiode = new ArbeidsforholdDto.Ansettelsesperiode(LocalDate.now(), LocalDate.now().plusMonths(2));
 
         when(personTjenesteMock.hentPersonFraIdent(fødselsnummer)).thenReturn(new PersonInfo("fornavn",
             "mellomnavn",
@@ -145,8 +143,6 @@ class RefusjonOmsorgsdagerServiceTest {
             LocalDate.now(),
             null,
             Kjønn.KVINNE));
-        when(arbeidstakerTjenesteMock.finnArbeidsforholdInnsenderHarTilgangTil(fødselsnummer, LocalDate.now()))
-            .thenReturn(List.of(new ArbeidsforholdDto(organisasjonsnummer, ansettelsesperiode)));
         when(inntektTjenesteMock.hentInntekt(any(), any(), any(), any(), any()))
             .thenReturn(new Inntektsopplysninger(new BigDecimal(10000), organisasjonsnummer, List.of()));
 
@@ -156,38 +152,14 @@ class RefusjonOmsorgsdagerServiceTest {
     }
 
     @Test
-    void hent_inntektsopplysninger_returnerer_null_om_man_ikke_finner_noen_arbeidsforhold() {
+    void hent_inntektsopplysninger_kaster_PERSON_IKKE_FUNNET_når_person_ikke_finnes() {
         var fødselsnummer = PersonIdent.fra("12345678910");
-        var organisasjonsnummer = "999999999";
-
-        when(personTjenesteMock.hentPersonFraIdent(fødselsnummer)).thenReturn(new PersonInfo("fornavn",
-            "mellomnavn",
-            "etternavn",
-            fødselsnummer,
-            null,
-            LocalDate.now(),
-            null,
-            Kjønn.KVINNE));
-        when(arbeidstakerTjenesteMock.finnArbeidsforholdInnsenderHarTilgangTil(fødselsnummer,
-            LocalDate.now())).thenReturn(List.of());
-
-        var response = service.hentInntektsopplysninger(fødselsnummer, organisasjonsnummer, LocalDate.now());
-
-        assertNull(response);
-    }
-
-    @Test
-    void hent_inntektsopplysninger_returnerer_null_om_person_ikke_finnes() {
-        var fødselsnummer = PersonIdent.fra("12345678910");
-        var organisasjonsnummer = "999999999";
-        var ansettelsesperiode = new ArbeidsforholdDto.Ansettelsesperiode(LocalDate.now(), LocalDate.now().plusMonths(2));
 
         when(personTjenesteMock.hentPersonFraIdent(fødselsnummer)).thenReturn(null);
-        when(arbeidstakerTjenesteMock.finnArbeidsforholdInnsenderHarTilgangTil(fødselsnummer, LocalDate.now()))
-            .thenReturn(List.of(new ArbeidsforholdDto(organisasjonsnummer, ansettelsesperiode)));
 
-        var response = service.hentInntektsopplysninger(fødselsnummer, "999999999", LocalDate.now());
+        var ex = assertThrows(FunksjonellException.class, () -> service.hentInntektsopplysninger(fødselsnummer, "999999999", LocalDate.now()));
 
-        assertNull(response);
+        assertThat(ex.getMessage()).contains("PERSON_IKKE_FUNNET");
+        verifyNoInteractions(inntektTjenesteMock);
     }
 }

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerServiceTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerServiceTest.java
@@ -1,9 +1,12 @@
 package no.nav.familie.inntektsmelding.refusjonomsorgsdager.tjenester;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
@@ -29,6 +32,7 @@ import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.InnloggetBrukerD
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.SlåOppArbeidstakerResponse;
 import no.nav.familie.inntektsmelding.typer.dto.Kjønn;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
+import no.nav.vedtak.exception.FunksjonellException;
 
 @ExtendWith(MockitoExtension.class)
 class RefusjonOmsorgsdagerServiceTest {
@@ -83,16 +87,30 @@ class RefusjonOmsorgsdagerServiceTest {
     }
 
     @Test
-    void slå_opp_arbeidstaker_skal_returnere_null_når_arbeidstaker_ikke_finnes() {
+    void slå_opp_arbeidstaker_kaster_PERSON_IKKE_FUNNET_når_person_ikke_finnes() {
         var fødselsnummer = PersonIdent.fra("12345678910");
-        var førsteFraværsdag = LocalDate.now();
 
         when(personTjenesteMock.hentPersonFraIdent(fødselsnummer)).thenReturn(null);
 
-        var response = service.hentArbeidstaker(fødselsnummer);
+        var ex = assertThrows(FunksjonellException.class, () -> service.hentArbeidstaker(fødselsnummer));
 
-        assertNull(response);
-        verify(arbeidstakerTjenesteMock).finnArbeidsforholdInnsenderHarTilgangTil(fødselsnummer, førsteFraværsdag);
+        assertThat(ex.getMessage()).contains("PERSON_IKKE_FUNNET");
+        verifyNoInteractions(arbeidstakerTjenesteMock);
+    }
+
+    @Test
+    void slå_opp_arbeidstaker_kaster_INGEN_ARBEIDSFORHOLD_når_ingen_arbeidsforhold() {
+        var fødselsnummer = PersonIdent.fra("12345678910");
+        var aktørId = AktørIdEntitet.dummy();
+
+        when(personTjenesteMock.hentPersonFraIdent(fødselsnummer)).thenReturn(
+            new PersonInfo("fornavn", "mellomnavn", "etternavn", fødselsnummer, aktørId, LocalDate.now(), null, Kjønn.KVINNE));
+        when(arbeidstakerTjenesteMock.finnArbeidsforholdInnsenderHarTilgangTil(fødselsnummer, LocalDate.now()))
+            .thenReturn(List.of());
+
+        var ex = assertThrows(FunksjonellException.class, () -> service.hentArbeidstaker(fødselsnummer));
+
+        assertThat(ex.getMessage()).contains("INGEN_ARBEIDSFORHOLD");
     }
 
     @Test


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi ønsker ikke å validere på om bruker er er knyttet til organisasjonene i aa-reg ved henting av inntekt. En bruker kan være unntatt registrering i aa-reg, men fortsatt ha registrert inntekt i aa-inntekt. 

Jira: https://jira.adeo.no/browse/TSFF-2581

### **Løsning**
- Fjerner sjekk av arbeidsforhold i `hentInntektsopplysninger`
- Gir feilmeldinger tilsvarende som i ArbeidsgiverinitiertDialogRest

### Andre endringer
Vi ønsker å gi bedre feilmeldinger til frontend og å skille mellom person ikke funnet og arbeidsgiver ikke funnet. Kaster feil i stedet for å tolke null.