### PR TITLE
TSFF-2606: Nytt endepunkt for å hente organisasjoner for arbeidsgiver

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsforholdDto.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsforholdDto.java
@@ -1,0 +1,7 @@
+package no.nav.familie.inntektsmelding.imdialog.rest;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ArbeidsforholdDto(@NotNull String organisasjonsnavn, @NotNull String organisasjonsnummer) {
+}
+

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
@@ -8,6 +8,7 @@ import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -41,6 +42,7 @@ public class ArbeidsgiverinitiertDialogRest {
     private static final String HENT_ARBEIDSFORHOLD_NYANSATT = "/arbeidsforhold/nyansatt";
     private static final String HENT_OPPLYSNINGER_NYANSATT = "/opplysninger/nyansatt";
     private static final String HENT_ARBEIDSGIVERE_UREGISTRERT = "/arbeidsgivere/uregistrert";
+    private static final String HENT_ARBEIDSGIVER_ORGANISASJONER = "/arbeidsgiver/organisasjoner";
     private static final String HENT_OPPLYSNINGER_UREGISTRERT = "/opplysninger/uregistrert";
 
     private GrunnlagTjeneste grunnlagTjeneste;
@@ -134,7 +136,9 @@ public class ArbeidsgiverinitiertDialogRest {
         arbeidsgiverinitiertDialogRestValiderer.validerPerson(personInfo);
         arbeidsgiverinitiertDialogRestValiderer.validerSakIK9(personInfo, request.ytelseType(), request.førsteFraværsdag());
 
-        HentArbeidsforholdResponse response = grunnlagTjeneste.hentSøkerinfoOgOrganisasjonerArbeidsgiverHarTilgangTil(personInfo);
+        // siden arbeidstager er uregistrert slår vi opp organisasjoner arbeidsgiver har tilgang til
+        var organisasjonerArbeidsgiverHarTilgangTil = grunnlagTjeneste.hentOrganisasjonerSomArbeidsgiverHarTilgangTil();
+        HentArbeidsforholdResponse response = grunnlagTjeneste.lagHentArbeidsforholdResponse(personInfo, organisasjonerArbeidsgiverHarTilgangTil);
         arbeidsgiverinitiertDialogRestValiderer.validerArbeidsforhold(response);
         return Response.ok(response).build();
     }
@@ -154,5 +158,15 @@ public class ArbeidsgiverinitiertDialogRest {
         Ytelsetype ytelsetype = KodeverkMapper.mapYtelsetype(request.ytelseType());
         HentOpplysningerResponse response = grunnlagTjeneste.hentOpplysninger(request.fødselsnummer(), ytelsetype, request.førsteFraværsdag(), request.organisasjonsnummer(), ForespørselType.ARBEIDSGIVERINITIERT_UREGISTRERT);
         return Response.ok(response).build();
+    }
+
+    @GET
+    @Path(HENT_ARBEIDSGIVER_ORGANISASJONER)
+    @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
+    @Tilgangskontrollert
+    public Response hentArbeidsgiverOrganisasjoner() {
+        LOG.info("Henter organisasjoner som arbeidsgiver har tilgang til");
+        var organisasjonerArbeidsgiverHarTilgangTil = grunnlagTjeneste.hentOrganisasjonerSomArbeidsgiverHarTilgangTil();
+        return Response.ok(new HentArbeidsgiverOrganisasjonerResponse(organisasjonerArbeidsgiverHarTilgangTil)).build();
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/HentArbeidsforholdResponse.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/HentArbeidsforholdResponse.java
@@ -12,6 +12,4 @@ public record HentArbeidsforholdResponse(@NotNull String fornavn,
                                          @NotNull String etternavn,
                                          @NotNull Kjønn kjønn,
                                          @NotNull @Valid Set<ArbeidsforholdDto> arbeidsforhold) {
-
-    public record ArbeidsforholdDto(@NotNull String organisasjonsnavn, @NotNull String organisasjonsnummer) {}
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/HentArbeidsforholdResponse.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/HentArbeidsforholdResponse.java
@@ -11,5 +11,5 @@ public record HentArbeidsforholdResponse(@NotNull String fornavn,
                                          String mellomnavn,
                                          @NotNull String etternavn,
                                          @NotNull Kjønn kjønn,
-                                         @NotNull @Valid Set<ArbeidsforholdDto> arbeidsforhold) {
+                                         @NotNull @Valid Set<OrganisasjonDto> arbeidsforhold) {
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/HentArbeidsgiverOrganisasjonerResponse.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/HentArbeidsgiverOrganisasjonerResponse.java
@@ -5,6 +5,6 @@ import java.util.Set;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
-public record HentArbeidsgiverOrganisasjonerResponse(@NotNull @Valid Set<ArbeidsforholdDto> organisasjoner) {
+public record HentArbeidsgiverOrganisasjonerResponse(@NotNull @Valid Set<OrganisasjonDto> organisasjoner) {
 }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/HentArbeidsgiverOrganisasjonerResponse.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/HentArbeidsgiverOrganisasjonerResponse.java
@@ -1,0 +1,10 @@
+package no.nav.familie.inntektsmelding.imdialog.rest;
+
+import java.util.Set;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+public record HentArbeidsgiverOrganisasjonerResponse(@NotNull @Valid Set<ArbeidsforholdDto> organisasjoner) {
+}
+

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/OrganisasjonDto.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/OrganisasjonDto.java
@@ -2,6 +2,6 @@ package no.nav.familie.inntektsmelding.imdialog.rest;
 
 import jakarta.validation.constraints.NotNull;
 
-public record ArbeidsforholdDto(@NotNull String organisasjonsnavn, @NotNull String organisasjonsnummer) {
+public record OrganisasjonDto(@NotNull String organisasjonsnavn, @NotNull String organisasjonsnummer) {
 }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
@@ -16,9 +16,9 @@ import org.slf4j.LoggerFactory;
 
 import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
 import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
-import no.nav.familie.inntektsmelding.imdialog.rest.ArbeidsforholdDto;
 import no.nav.familie.inntektsmelding.imdialog.rest.HentArbeidsforholdResponse;
 import no.nav.familie.inntektsmelding.imdialog.rest.HentOpplysningerResponse;
+import no.nav.familie.inntektsmelding.imdialog.rest.OrganisasjonDto;
 import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.InntektTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.OrganisasjonTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
@@ -200,8 +200,8 @@ public class GrunnlagTjeneste {
             return Optional.empty();
         }
 
-        var arbeidsforholdDto = arbeidsforholdBrukerHarTilgangTil.stream()
-            .map(a -> new ArbeidsforholdDto(organisasjonTjeneste.finnOrganisasjon(a.organisasjonsnummer()).navn(),
+        var arbeidsforhold = arbeidsforholdBrukerHarTilgangTil.stream()
+            .map(a -> new OrganisasjonDto(organisasjonTjeneste.finnOrganisasjon(a.organisasjonsnummer()).navn(),
                 a.organisasjonsnummer()))
             .collect(Collectors.toSet());
 
@@ -209,23 +209,23 @@ public class GrunnlagTjeneste {
             personInfo.mellomnavn(),
             personInfo.etternavn(),
             personInfo.kjønn(),
-            arbeidsforholdDto));
+            arbeidsforhold));
     }
 
-    public Set<ArbeidsforholdDto> hentOrganisasjonerSomArbeidsgiverHarTilgangTil() {
+    public Set<OrganisasjonDto> hentOrganisasjonerSomArbeidsgiverHarTilgangTil() {
         var organisasjonerArbeidsgiverHarTilgangTil = arbeidstakerTjeneste.finnOrganisasjonerArbeidsgiverHarTilgangTil();
 
         var organisasjoner = organisasjonerArbeidsgiverHarTilgangTil.stream()
             .map(orgnrDto -> {
                 String organisasjonsnavn = organisasjonTjeneste.finnOrganisasjon(orgnrDto.orgnr()).navn();
-                return new ArbeidsforholdDto(organisasjonsnavn, orgnrDto.orgnr());
+                return new OrganisasjonDto(organisasjonsnavn, orgnrDto.orgnr());
             })
             .collect(Collectors.toSet());
         return organisasjoner;
     }
 
     public HentArbeidsforholdResponse lagHentArbeidsforholdResponse(PersonInfo personInfo,
-                                                                    Set<ArbeidsforholdDto> organisasjonerArbeidsgiverHarTilgangTil) {
+                                                                    Set<OrganisasjonDto> organisasjonerArbeidsgiverHarTilgangTil) {
         return new HentArbeidsforholdResponse(personInfo.fornavn(),
             personInfo.mellomnavn(),
             personInfo.etternavn(),

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -15,6 +16,7 @@ import org.slf4j.LoggerFactory;
 
 import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
 import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
+import no.nav.familie.inntektsmelding.imdialog.rest.ArbeidsforholdDto;
 import no.nav.familie.inntektsmelding.imdialog.rest.HentArbeidsforholdResponse;
 import no.nav.familie.inntektsmelding.imdialog.rest.HentOpplysningerResponse;
 import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.InntektTjeneste;
@@ -199,7 +201,7 @@ public class GrunnlagTjeneste {
         }
 
         var arbeidsforholdDto = arbeidsforholdBrukerHarTilgangTil.stream()
-            .map(a -> new HentArbeidsforholdResponse.ArbeidsforholdDto(organisasjonTjeneste.finnOrganisasjon(a.organisasjonsnummer()).navn(),
+            .map(a -> new ArbeidsforholdDto(organisasjonTjeneste.finnOrganisasjon(a.organisasjonsnummer()).navn(),
                 a.organisasjonsnummer()))
             .collect(Collectors.toSet());
 
@@ -210,19 +212,25 @@ public class GrunnlagTjeneste {
             arbeidsforholdDto));
     }
 
-    public HentArbeidsforholdResponse hentSøkerinfoOgOrganisasjonerArbeidsgiverHarTilgangTil(PersonInfo personInfo) {
+    public Set<ArbeidsforholdDto> hentOrganisasjonerSomArbeidsgiverHarTilgangTil() {
         var organisasjonerArbeidsgiverHarTilgangTil = arbeidstakerTjeneste.finnOrganisasjonerArbeidsgiverHarTilgangTil();
 
         var organisasjoner = organisasjonerArbeidsgiverHarTilgangTil.stream()
-            .map(orgnrDto -> new HentArbeidsforholdResponse.ArbeidsforholdDto(organisasjonTjeneste.finnOrganisasjon(orgnrDto.orgnr()).navn(),
-                orgnrDto.orgnr()))
+            .map(orgnrDto -> {
+                String organisasjonsnavn = organisasjonTjeneste.finnOrganisasjon(orgnrDto.orgnr()).navn();
+                return new ArbeidsforholdDto(organisasjonsnavn, orgnrDto.orgnr());
+            })
             .collect(Collectors.toSet());
+        return organisasjoner;
+    }
 
+    public HentArbeidsforholdResponse lagHentArbeidsforholdResponse(PersonInfo personInfo,
+                                                                    Set<ArbeidsforholdDto> organisasjonerArbeidsgiverHarTilgangTil) {
         return new HentArbeidsforholdResponse(personInfo.fornavn(),
             personInfo.mellomnavn(),
             personInfo.etternavn(),
             personInfo.kjønn(),
-            organisasjoner);
+            organisasjonerArbeidsgiverHarTilgangTil);
     }
 
     public boolean finnesOrgnummerIAaregPåPerson(PersonIdent personIdent, String organisasjonsnummer, LocalDate førsteFraværsdag) {

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/aareg/AaregRestKlient.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/aareg/AaregRestKlient.java
@@ -19,7 +19,6 @@ import no.nav.vedtak.felles.integrasjon.rest.RestClientConfig;
 import no.nav.vedtak.felles.integrasjon.rest.RestConfig;
 import no.nav.vedtak.felles.integrasjon.rest.RestRequest;
 import no.nav.vedtak.felles.integrasjon.rest.TokenFlow;
-
 import no.nav.vedtak.mapper.json.DefaultJsonMapper;
 
 /*

--- a/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjenesteTest.java
@@ -238,7 +238,8 @@ class GrunnlagTjenesteTest {
         when(organisasjonTjeneste.finnOrganisasjon(orgnr1.orgnr())).thenReturn(new Organisasjon(navn1, orgnr1.orgnr()));
         when(organisasjonTjeneste.finnOrganisasjon(orgnr2.orgnr())).thenReturn(new Organisasjon(navn2, orgnr2.orgnr()));
         // Act
-        var response = grunnlagTjeneste.hentSøkerinfoOgOrganisasjonerArbeidsgiverHarTilgangTil(personInfo);
+        var organisasjoner = grunnlagTjeneste.hentOrganisasjonerSomArbeidsgiverHarTilgangTil();
+        var response = grunnlagTjeneste.lagHentArbeidsforholdResponse(personInfo, organisasjoner);
 
         // Assert
         assertThat(response).isNotNull();


### PR DESCRIPTION
### **Behov / Bakgrunn**
Ved arbeidsgiver initiert inntektsmelding for uregistrerte kan vi ikke slå opp arbeidstagers arbeidsforhold siden de er nettopp uregistrerte. Vi slår derfor opp organisasjonene som arbeidsgiver har tilgang til. 

For omsorgspenger refusjon ønsker vi å gjøre tilsvarende sjekk, men har kun behov for å sjekke orgnummer, ikke sak i k9 eller personopplysninger. 

### **Løsning**
- Nytt endepunkt for å hente organisasjoner for arbeidsgiver. 
- Trekker ut ArbeidsforholdDto fra HentArbeidsforholdResponse som vi kan gjenbruke