### PR TITLE
Tsff 2580 må treffe stp for uregistrerte 

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
@@ -42,6 +42,7 @@ public class ArbeidsgiverinitiertDialogRest {
     private static final String HENT_ARBEIDSGIVERE_UREGISTRERT = "/arbeidsgivere/uregistrert";
     private static final String HENT_ARBEIDSGIVER_ORGANISASJONER = "/arbeidsgiver/organisasjoner";
     private static final String HENT_OPPLYSNINGER_UREGISTRERT = "/opplysninger/uregistrert";
+    private static final String HENT_ARBEIDSTAKER = "/arbeidstaker";
 
     private GrunnlagTjeneste grunnlagTjeneste;
     private PersonTjeneste personTjeneste;
@@ -85,6 +86,23 @@ public class ArbeidsgiverinitiertDialogRest {
         return Response.ok(hentOpplysningerResponse).build();
     }
 
+    @POST
+    @Path(HENT_ARBEIDSTAKER)
+    @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
+    @Tilgangskontrollert
+    public Response hentArbeidstaker(@Valid @NotNull HentArbeidstakerRequest request) {
+        LOG.info("Henter arbeidstaker");
+        PersonInfo personInfo = personTjeneste.hentPersonFraIdent(request.fødselsnummer());
+        arbeidsgiverinitiertDialogRestValiderer.validerPerson(personInfo);
+
+        var response = new HentArbeidstakerResponse(personInfo.fornavn(), personInfo.mellomnavn(), personInfo.etternavn(), personInfo.kjønn());
+        return Response.ok(response).build();
+    }
+
+    /**
+     * @deprecated Bruk {@link #hentArbeidstaker(HentArbeidstakerRequest)} i stedet.
+     */
+    @Deprecated
     @POST
     @Path(HENT_ARBEIDSGIVERE_UREGISTRERT)
     @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
@@ -130,12 +130,12 @@ public class ArbeidsgiverinitiertDialogRest {
     public Response hentOpplysningerUregistrert(@Valid @NotNull OpplysningerRequestDto request) {
         LOG.info("Henter opplysninger for uregistrert søker");
         PersonInfo personInfo = personTjeneste.hentPersonFraIdent(request.fødselsnummer());
-        arbeidsgiverinitiertDialogRestValiderer.validerPerson(personInfo);
 
-        Ytelsetype ytelsetype = KodeverkMapper.mapYtelsetype(request.ytelseType());
+        arbeidsgiverinitiertDialogRestValiderer.validerPerson(personInfo);
         arbeidsgiverinitiertDialogRestValiderer.validerSakIK9(personInfo, request.ytelseType(), request.førsteFraværsdag(), FRAVÆRSDAG_ER_FØRSTE_FRAVÆRSDAG_I_SØKNADSPERIODE);
         arbeidsgiverinitiertDialogRestValiderer.validerAtOrgnummerIkkeFinnesIAaregPåPerson(personInfo, request.organisasjonsnummer(), request.førsteFraværsdag());
 
+        Ytelsetype ytelsetype = KodeverkMapper.mapYtelsetype(request.ytelseType());
         HentOpplysningerResponse response = grunnlagTjeneste.hentOpplysninger(request.fødselsnummer(), ytelsetype, request.førsteFraværsdag(), request.organisasjonsnummer(), ForespørselType.ARBEIDSGIVERINITIERT_UREGISTRERT);
         return Response.ok(response).build();
     }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
@@ -36,8 +36,6 @@ public class ArbeidsgiverinitiertDialogRest {
     private static final Logger LOG = LoggerFactory.getLogger(ArbeidsgiverinitiertDialogRest.class);
 
     public static final String BASE_PATH = "/arbeidsgiverinitiert";
-    private static final String HENT_ARBEIDSFORHOLD = "/arbeidsforhold";
-    private static final String HENT_OPPLYSNINGER = "/opplysninger";
     private static final String HENT_ARBEIDSFORHOLD_NYANSATT = "/arbeidsforhold/nyansatt";
     private static final String HENT_OPPLYSNINGER_NYANSATT = "/opplysninger/nyansatt";
     private static final String HENT_ARBEIDSGIVERE_UREGISTRERT = "/arbeidsgivere/uregistrert";
@@ -56,44 +54,6 @@ public class ArbeidsgiverinitiertDialogRest {
         this.grunnlagTjeneste = grunnlagTjeneste;
         this.personTjeneste = personTjeneste;
         this.arbeidsgiverinitiertDialogRestValiderer = arbeidsgiverinitiertDialogRestValiderer;
-    }
-
-    /**
-     * @deprecated Bruk {@link #hentArbeidsforholdNyansatt(HentArbeidsforholdRequest)} i stedet.
-     */
-    @Deprecated
-    @POST
-    @Path(HENT_ARBEIDSFORHOLD)
-    @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
-    @Tilgangskontrollert
-    public Response hentArbeidsforhold(@Valid @NotNull HentArbeidsforholdRequest request) {
-        LOG.info("Henter arbeidsforhold for søker");
-
-        // Sjekk at person finnes
-        PersonInfo personInfo = personTjeneste.hentPersonFraIdent(request.fødselsnummer());
-        if (personInfo == null) {
-            return Response.status(Response.Status.NOT_FOUND).build();
-        }
-
-        arbeidsgiverinitiertDialogRestValiderer.validerSakIK9(personInfo, request.ytelseType(), request.førsteFraværsdag());
-
-        Optional<HentArbeidsforholdResponse> response = grunnlagTjeneste.finnArbeidsforholdForFnr(personInfo, request.førsteFraværsdag());
-        return response.map(r ->Response.ok(r).build()).orElseGet(() -> Response.status(Response.Status.NOT_FOUND).build());
-    }
-
-    /**
-     * @deprecated Bruk {@link #hentOpplysningerNyansatt(OpplysningerRequestDto)} i stedet.
-     */
-    @Deprecated
-    @POST
-    @Path(HENT_OPPLYSNINGER)
-    @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
-    @Tilgangskontrollert
-    public Response hentOpplysninger(@Valid @NotNull OpplysningerRequestDto request) {
-        LOG.info("Henter opplysninger for søker");
-        Ytelsetype ytelsetype = KodeverkMapper.mapYtelsetype(request.ytelseType());
-        HentOpplysningerResponse hentOpplysningerResponse = grunnlagTjeneste.hentOpplysninger(request.fødselsnummer(), ytelsetype, request.førsteFraværsdag(), request.organisasjonsnummer(), ForespørselType.ARBEIDSGIVERINITIERT_NYANSATT);
-        return Response.ok(hentOpplysningerResponse).build();
     }
 
     @POST

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
@@ -105,6 +105,12 @@ public class ArbeidsgiverinitiertDialogRest {
 
         arbeidsgiverinitiertDialogRestValiderer.validerPerson(personInfo);
 
+        Ytelsetype ytelsetype = KodeverkMapper.mapYtelsetype(request.ytelseType());
+        List<FagsakInfo> fagsakerIK9Sak =  grunnlagTjeneste.hentFagsakerIK9(personInfo, ytelsetype);
+
+        arbeidsgiverinitiertDialogRestValiderer.validerAtFraværsdatoErFørsteFraværsdagISøknadsperiode(request.førsteFraværsdag(), fagsakerIK9Sak, ytelsetype);
+        arbeidsgiverinitiertDialogRestValiderer.validerAtSakIkkeVenterPåForTidligSøknad(fagsakerIK9Sak, ytelsetype);
+
         // siden arbeidstager er uregistrert slår vi opp organisasjoner arbeidsgiver har tilgang til
         var organisasjonerArbeidsgiverHarTilgangTil = grunnlagTjeneste.hentOrganisasjonerSomArbeidsgiverHarTilgangTil();
         HentArbeidsforholdResponse response = grunnlagTjeneste.lagHentArbeidsforholdResponse(personInfo, organisasjonerArbeidsgiverHarTilgangTil);

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
@@ -1,6 +1,8 @@
 package no.nav.familie.inntektsmelding.imdialog.rest;
 
-import java.util.List;
+import static no.nav.familie.inntektsmelding.imdialog.tjenester.ArbeidsgiverinitiertDialogRestValiderer.SøknadsperiodeValidering.FRAVÆRSDAG_ER_FØRSTE_FRAVÆRSDAG_I_SØKNADSPERIODE;
+import static no.nav.familie.inntektsmelding.imdialog.tjenester.ArbeidsgiverinitiertDialogRestValiderer.SøknadsperiodeValidering.FRAVÆRSDAG_INNENFOR_SØKNADSPERIODE;
+
 import java.util.Optional;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -21,7 +23,6 @@ import org.slf4j.LoggerFactory;
 
 import no.nav.familie.inntektsmelding.imdialog.tjenester.ArbeidsgiverinitiertDialogRestValiderer;
 import no.nav.familie.inntektsmelding.imdialog.tjenester.GrunnlagTjeneste;
-import no.nav.familie.inntektsmelding.integrasjoner.k9sak.FagsakInfo;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonInfo;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
 import no.nav.familie.inntektsmelding.koder.ForespørselType;
@@ -69,11 +70,7 @@ public class ArbeidsgiverinitiertDialogRest {
         LOG.info("Henter arbeidsforhold for søker");
         PersonInfo personInfo = personTjeneste.hentPersonFraIdent(request.fødselsnummer());
         arbeidsgiverinitiertDialogRestValiderer.validerPerson(personInfo);
-
-        Ytelsetype ytelsetype = KodeverkMapper.mapYtelsetype(request.ytelseType());
-        List<FagsakInfo> fagsakerIK9Sak =  grunnlagTjeneste.hentFagsakerIK9(personInfo, ytelsetype);
-        arbeidsgiverinitiertDialogRestValiderer.validerAtFraværsdatoTrefferEnSøknadsperiodeIK9(request.førsteFraværsdag(), fagsakerIK9Sak, ytelsetype);
-        arbeidsgiverinitiertDialogRestValiderer.validerAtSakIkkeVenterPåForTidligSøknad(fagsakerIK9Sak, ytelsetype);
+        arbeidsgiverinitiertDialogRestValiderer.validerSakIK9(personInfo, request.ytelseType(), request.førsteFraværsdag(), FRAVÆRSDAG_INNENFOR_SØKNADSPERIODE);
 
         Optional<HentArbeidsforholdResponse> response = grunnlagTjeneste.finnArbeidsforholdForFnr(personInfo, request.førsteFraværsdag());
         arbeidsgiverinitiertDialogRestValiderer.validerArbeidsforhold(response);
@@ -104,12 +101,7 @@ public class ArbeidsgiverinitiertDialogRest {
         PersonInfo personInfo = personTjeneste.hentPersonFraIdent(request.fødselsnummer());
 
         arbeidsgiverinitiertDialogRestValiderer.validerPerson(personInfo);
-
-        Ytelsetype ytelsetype = KodeverkMapper.mapYtelsetype(request.ytelseType());
-        List<FagsakInfo> fagsakerIK9Sak =  grunnlagTjeneste.hentFagsakerIK9(personInfo, ytelsetype);
-
-        arbeidsgiverinitiertDialogRestValiderer.validerAtFraværsdatoErFørsteFraværsdagISøknadsperiode(request.førsteFraværsdag(), fagsakerIK9Sak, ytelsetype);
-        arbeidsgiverinitiertDialogRestValiderer.validerAtSakIkkeVenterPåForTidligSøknad(fagsakerIK9Sak, ytelsetype);
+        arbeidsgiverinitiertDialogRestValiderer.validerSakIK9(personInfo, request.ytelseType(), request.førsteFraværsdag(), FRAVÆRSDAG_ER_FØRSTE_FRAVÆRSDAG_I_SØKNADSPERIODE);
 
         // siden arbeidstager er uregistrert slår vi opp organisasjoner arbeidsgiver har tilgang til
         var organisasjonerArbeidsgiverHarTilgangTil = grunnlagTjeneste.hentOrganisasjonerSomArbeidsgiverHarTilgangTil();
@@ -141,10 +133,7 @@ public class ArbeidsgiverinitiertDialogRest {
         arbeidsgiverinitiertDialogRestValiderer.validerPerson(personInfo);
 
         Ytelsetype ytelsetype = KodeverkMapper.mapYtelsetype(request.ytelseType());
-        List<FagsakInfo> fagsakerIK9Sak =  grunnlagTjeneste.hentFagsakerIK9(personInfo, ytelsetype);
-
-        arbeidsgiverinitiertDialogRestValiderer.validerAtFraværsdatoErFørsteFraværsdagISøknadsperiode(request.førsteFraværsdag(), fagsakerIK9Sak, ytelsetype);
-        arbeidsgiverinitiertDialogRestValiderer.validerAtSakIkkeVenterPåForTidligSøknad(fagsakerIK9Sak, ytelsetype);
+        arbeidsgiverinitiertDialogRestValiderer.validerSakIK9(personInfo, request.ytelseType(), request.førsteFraværsdag(), FRAVÆRSDAG_ER_FØRSTE_FRAVÆRSDAG_I_SØKNADSPERIODE);
         arbeidsgiverinitiertDialogRestValiderer.validerAtOrgnummerIkkeFinnesIAaregPåPerson(personInfo, request.organisasjonsnummer(), request.førsteFraværsdag());
 
         HentOpplysningerResponse response = grunnlagTjeneste.hentOpplysninger(request.fødselsnummer(), ytelsetype, request.førsteFraværsdag(), request.organisasjonsnummer(), ForespørselType.ARBEIDSGIVERINITIERT_UREGISTRERT);

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
@@ -112,7 +112,6 @@ public class ArbeidsgiverinitiertDialogRest {
         PersonInfo personInfo = personTjeneste.hentPersonFraIdent(request.fødselsnummer());
 
         arbeidsgiverinitiertDialogRestValiderer.validerPerson(personInfo);
-        arbeidsgiverinitiertDialogRestValiderer.validerSakIK9(personInfo, request.ytelseType(), request.førsteFraværsdag());
 
         // siden arbeidstager er uregistrert slår vi opp organisasjoner arbeidsgiver har tilgang til
         var organisasjonerArbeidsgiverHarTilgangTil = grunnlagTjeneste.hentOrganisasjonerSomArbeidsgiverHarTilgangTil();

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
@@ -1,5 +1,6 @@
 package no.nav.familie.inntektsmelding.imdialog.rest;
 
+import java.util.List;
 import java.util.Optional;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -20,6 +21,7 @@ import org.slf4j.LoggerFactory;
 
 import no.nav.familie.inntektsmelding.imdialog.tjenester.ArbeidsgiverinitiertDialogRestValiderer;
 import no.nav.familie.inntektsmelding.imdialog.tjenester.GrunnlagTjeneste;
+import no.nav.familie.inntektsmelding.integrasjoner.k9sak.FagsakInfo;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonInfo;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
 import no.nav.familie.inntektsmelding.koder.ForespørselType;
@@ -66,9 +68,12 @@ public class ArbeidsgiverinitiertDialogRest {
     public Response hentArbeidsforholdNyansatt(@Valid @NotNull HentArbeidsforholdRequest request) {
         LOG.info("Henter arbeidsforhold for søker");
         PersonInfo personInfo = personTjeneste.hentPersonFraIdent(request.fødselsnummer());
-
         arbeidsgiverinitiertDialogRestValiderer.validerPerson(personInfo);
-        arbeidsgiverinitiertDialogRestValiderer.validerSakIK9(personInfo, request.ytelseType(), request.førsteFraværsdag());
+
+        Ytelsetype ytelsetype = KodeverkMapper.mapYtelsetype(request.ytelseType());
+        List<FagsakInfo> fagsakerIK9Sak =  grunnlagTjeneste.hentFagsakerIK9(personInfo, ytelsetype);
+        arbeidsgiverinitiertDialogRestValiderer.validerAtFraværsdatoTrefferEnSøknadsperiodeIK9(request.førsteFraværsdag(), fagsakerIK9Sak, ytelsetype);
+        arbeidsgiverinitiertDialogRestValiderer.validerAtSakIkkeVenterPåForTidligSøknad(fagsakerIK9Sak, ytelsetype);
 
         Optional<HentArbeidsforholdResponse> response = grunnlagTjeneste.finnArbeidsforholdForFnr(personInfo, request.førsteFraværsdag());
         arbeidsgiverinitiertDialogRestValiderer.validerArbeidsforhold(response);
@@ -127,12 +132,15 @@ public class ArbeidsgiverinitiertDialogRest {
     public Response hentOpplysningerUregistrert(@Valid @NotNull OpplysningerRequestDto request) {
         LOG.info("Henter opplysninger for uregistrert søker");
         PersonInfo personInfo = personTjeneste.hentPersonFraIdent(request.fødselsnummer());
-
         arbeidsgiverinitiertDialogRestValiderer.validerPerson(personInfo);
-        arbeidsgiverinitiertDialogRestValiderer.validerSakIK9(personInfo, request.ytelseType(), request.førsteFraværsdag());
-        arbeidsgiverinitiertDialogRestValiderer.validerAtOrgnummerIkkeFinnesIAaregPåPerson(personInfo, request.organisasjonsnummer(), request.førsteFraværsdag());
 
         Ytelsetype ytelsetype = KodeverkMapper.mapYtelsetype(request.ytelseType());
+        List<FagsakInfo> fagsakerIK9Sak =  grunnlagTjeneste.hentFagsakerIK9(personInfo, ytelsetype);
+
+        arbeidsgiverinitiertDialogRestValiderer.validerAtFraværsdatoErFørsteFraværsdagISøknadsperiode(request.førsteFraværsdag(), fagsakerIK9Sak, ytelsetype);
+        arbeidsgiverinitiertDialogRestValiderer.validerAtSakIkkeVenterPåForTidligSøknad(fagsakerIK9Sak, ytelsetype);
+        arbeidsgiverinitiertDialogRestValiderer.validerAtOrgnummerIkkeFinnesIAaregPåPerson(personInfo, request.organisasjonsnummer(), request.førsteFraværsdag());
+
         HentOpplysningerResponse response = grunnlagTjeneste.hentOpplysninger(request.fødselsnummer(), ytelsetype, request.førsteFraværsdag(), request.organisasjonsnummer(), ForespørselType.ARBEIDSGIVERINITIERT_UREGISTRERT);
         return Response.ok(response).build();
     }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/ArbeidsgiverinitiertDialogRest.java
@@ -91,19 +91,6 @@ public class ArbeidsgiverinitiertDialogRest {
         return Response.ok(hentOpplysningerResponse).build();
     }
 
-    @POST
-    @Path(HENT_ARBEIDSTAKER)
-    @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
-    @Tilgangskontrollert
-    public Response hentArbeidstaker(@Valid @NotNull HentArbeidstakerRequest request) {
-        LOG.info("Henter arbeidstaker");
-        PersonInfo personInfo = personTjeneste.hentPersonFraIdent(request.fødselsnummer());
-        arbeidsgiverinitiertDialogRestValiderer.validerPerson(personInfo);
-
-        var response = new HentArbeidstakerResponse(personInfo.fornavn(), personInfo.mellomnavn(), personInfo.etternavn(), personInfo.kjønn());
-        return Response.ok(response).build();
-    }
-
     /**
      * @deprecated Bruk {@link #hentArbeidstaker(HentArbeidstakerRequest)} i stedet.
      */
@@ -122,6 +109,19 @@ public class ArbeidsgiverinitiertDialogRest {
         var organisasjonerArbeidsgiverHarTilgangTil = grunnlagTjeneste.hentOrganisasjonerSomArbeidsgiverHarTilgangTil();
         HentArbeidsforholdResponse response = grunnlagTjeneste.lagHentArbeidsforholdResponse(personInfo, organisasjonerArbeidsgiverHarTilgangTil);
         arbeidsgiverinitiertDialogRestValiderer.validerArbeidsforhold(response);
+        return Response.ok(response).build();
+    }
+
+    @POST
+    @Path(HENT_ARBEIDSTAKER)
+    @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
+    @Tilgangskontrollert
+    public Response hentArbeidstaker(@Valid @NotNull HentArbeidstakerRequest request) {
+        LOG.info("Henter arbeidstaker");
+        PersonInfo personInfo = personTjeneste.hentPersonFraIdent(request.fødselsnummer());
+        arbeidsgiverinitiertDialogRestValiderer.validerPerson(personInfo);
+
+        var response = new HentArbeidstakerResponse(personInfo.fornavn(), personInfo.mellomnavn(), personInfo.etternavn(), personInfo.kjønn());
         return Response.ok(response).build();
     }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/HentArbeidstakerRequest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/HentArbeidstakerRequest.java
@@ -1,0 +1,10 @@
+package no.nav.familie.inntektsmelding.imdialog.rest;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
+
+public record HentArbeidstakerRequest(@Valid @NotNull PersonIdent fødselsnummer) {
+}
+

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/HentArbeidstakerResponse.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/HentArbeidstakerResponse.java
@@ -1,0 +1,12 @@
+package no.nav.familie.inntektsmelding.imdialog.rest;
+
+import jakarta.validation.constraints.NotNull;
+
+import no.nav.familie.inntektsmelding.typer.dto.Kjønn;
+
+public record HentArbeidstakerResponse(@NotNull String fornavn,
+                                       String mellomnavn,
+                                       @NotNull String etternavn,
+                                       @NotNull Kjønn kjønn) {
+}
+

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/ArbeidsgiverinitiertDialogRestValiderer.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/ArbeidsgiverinitiertDialogRestValiderer.java
@@ -84,8 +84,8 @@ public class ArbeidsgiverinitiertDialogRestValiderer {
             .anyMatch(søknadsperiode -> søknadsperiode.fom().isEqual(førsteFraværsdag));
 
         if (!erFørsteFraværsdag) {
-            var feilmelding = String.format("Du kan ikke sende inn inntektsmelding på %s for denne personen", ytelsetype);
-            throw new FunksjonellException("INGEN_SAK_FUNNET", feilmelding, null, null);
+            var feilmelding = String.format("Du kan ikke sende inn inntektsmelding på %s for denne personen på denne fraværsdatoen %s", ytelsetype, førsteFraværsdag);
+            throw new FunksjonellException("INGEN_SAK_FUNNET_FOR_DATO", feilmelding, null, null);
         }
     }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/ArbeidsgiverinitiertDialogRestValiderer.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/ArbeidsgiverinitiertDialogRestValiderer.java
@@ -50,7 +50,7 @@ public class ArbeidsgiverinitiertDialogRestValiderer {
             .toList();
 
         boolean fraværsdagErInnenforSøknadsperiode = søknadsPerioderForFagsakerIK9.stream()
-            .anyMatch(søknandsperiode -> søknandsperiode.inneholderDato(førsteFraværsdag));
+            .anyMatch(søknadsperiode -> søknadsperiode.inneholderDato(førsteFraværsdag));
 
         if (!fraværsdagErInnenforSøknadsperiode) {
             var feilmelding = String.format("Du kan ikke sende inn inntektsmelding på %s for denne personen", ytelsetype);
@@ -64,7 +64,7 @@ public class ArbeidsgiverinitiertDialogRestValiderer {
             .toList();
 
         boolean erFørsteFraværsdag = søknadsPerioderForFagsakerIK9.stream()
-            .anyMatch(søknandsperiode -> søknandsperiode.fom().isEqual(førsteFraværsdag));
+            .anyMatch(søknadsperiode -> søknadsperiode.fom().isEqual(førsteFraværsdag));
 
         if (!erFørsteFraværsdag) {
             var feilmelding = String.format("Du kan ikke sende inn inntektsmelding på %s for denne personen", ytelsetype);

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/ArbeidsgiverinitiertDialogRestValiderer.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/ArbeidsgiverinitiertDialogRestValiderer.java
@@ -11,8 +11,10 @@ import no.nav.familie.inntektsmelding.imdialog.rest.HentArbeidsforholdResponse;
 import no.nav.familie.inntektsmelding.integrasjoner.k9sak.FagsakInfo;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonInfo;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.familie.inntektsmelding.typer.dto.KodeverkMapper;
 import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
 import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
+import no.nav.familie.inntektsmelding.typer.dto.YtelseTypeDto;
 import no.nav.vedtak.exception.FunksjonellException;
 
 @ApplicationScoped
@@ -46,8 +48,20 @@ public class ArbeidsgiverinitiertDialogRestValiderer {
             throw new FunksjonellException("INGEN_ARBEIDSFORHOLD", "Fant ingen arbeidsforhold på brukeren", null, null);
         }
     }
+    public void validerSakIK9(PersonInfo personInfo, YtelseTypeDto ytelseType, LocalDate førsteFraværsdag, SøknadsperiodeValidering validering) {
+        Ytelsetype ytelsetype = KodeverkMapper.mapYtelsetype(ytelseType);
+        List<FagsakInfo> fagsakerIK9Sak =  grunnlagTjeneste.hentFagsakerIK9(personInfo, ytelsetype);
 
-    public void validerAtFraværsdatoTrefferEnSøknadsperiodeIK9(LocalDate førsteFraværsdag, List<FagsakInfo> fagsakerIK9, Ytelsetype ytelsetype) {
+        validerAtSakIkkeVenterPåForTidligSøknad(fagsakerIK9Sak, ytelsetype);
+
+        if (SøknadsperiodeValidering.FRAVÆRSDAG_INNENFOR_SØKNADSPERIODE.equals(validering)) {
+            validerAtFraværsdatoErInnenforEnSøknadsperiodeIK9(førsteFraværsdag, fagsakerIK9Sak, ytelsetype);
+        } else if (SøknadsperiodeValidering.FRAVÆRSDAG_ER_FØRSTE_FRAVÆRSDAG_I_SØKNADSPERIODE.equals(validering)) {
+            validerAtFraværsdatoErFørsteFraværsdagISøknadsperiode(førsteFraværsdag, fagsakerIK9Sak, ytelsetype);
+        }
+    }
+
+    public void validerAtFraværsdatoErInnenforEnSøknadsperiodeIK9(LocalDate førsteFraværsdag, List<FagsakInfo> fagsakerIK9, Ytelsetype ytelsetype) {
         List<PeriodeDto> søknadsPerioderForFagsakerIK9 = fagsakerIK9.stream()
             .flatMap(fagsak -> fagsak.søknadsPerioder().stream())
             .toList();
@@ -88,5 +102,10 @@ public class ArbeidsgiverinitiertDialogRestValiderer {
             var tekst = "Det finnes rapportering i aa-registeret på organisasjonsnummeret. Nav vil be om inntektsmelding når vi trenger det";
             throw new FunksjonellException("FINNES_I_AAREG", tekst, null, null);
         }
+    }
+
+    public enum SøknadsperiodeValidering {
+        FRAVÆRSDAG_INNENFOR_SØKNADSPERIODE,
+        FRAVÆRSDAG_ER_FØRSTE_FRAVÆRSDAG_I_SØKNADSPERIODE
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/ArbeidsgiverinitiertDialogRestValiderer.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/ArbeidsgiverinitiertDialogRestValiderer.java
@@ -48,6 +48,7 @@ public class ArbeidsgiverinitiertDialogRestValiderer {
             throw new FunksjonellException("INGEN_ARBEIDSFORHOLD", "Fant ingen arbeidsforhold på brukeren", null, null);
         }
     }
+
     public void validerSakIK9(PersonInfo personInfo, YtelseTypeDto ytelseType, LocalDate førsteFraværsdag, SøknadsperiodeValidering validering) {
         Ytelsetype ytelsetype = KodeverkMapper.mapYtelsetype(ytelseType);
         List<FagsakInfo> fagsakerIK9Sak =  grunnlagTjeneste.hentFagsakerIK9(personInfo, ytelsetype);

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/ArbeidsgiverinitiertDialogRestValiderer.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/ArbeidsgiverinitiertDialogRestValiderer.java
@@ -4,7 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import no.nav.familie.inntektsmelding.imdialog.rest.HentArbeidsforholdResponse;
@@ -15,11 +15,14 @@ import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
 import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
 import no.nav.vedtak.exception.FunksjonellException;
 
-@Dependent
+@ApplicationScoped
 public class ArbeidsgiverinitiertDialogRestValiderer {
 
-    private final GrunnlagTjeneste grunnlagTjeneste;
+    private GrunnlagTjeneste grunnlagTjeneste;
 
+    protected ArbeidsgiverinitiertDialogRestValiderer() {
+        // CDI proxy
+    }
 
     @Inject
     public ArbeidsgiverinitiertDialogRestValiderer(GrunnlagTjeneste grunnlagTjeneste) {

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/ArbeidsgiverinitiertDialogRestValiderer.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/ArbeidsgiverinitiertDialogRestValiderer.java
@@ -9,7 +9,6 @@ import jakarta.inject.Inject;
 
 import no.nav.familie.inntektsmelding.imdialog.rest.HentArbeidsforholdResponse;
 import no.nav.familie.inntektsmelding.integrasjoner.k9sak.FagsakInfo;
-import no.nav.familie.inntektsmelding.integrasjoner.k9sak.K9SakTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonInfo;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
@@ -20,13 +19,11 @@ import no.nav.vedtak.exception.FunksjonellException;
 public class ArbeidsgiverinitiertDialogRestValiderer {
 
     private final GrunnlagTjeneste grunnlagTjeneste;
-    private final K9SakTjeneste k9SakTjeneste;
 
 
     @Inject
-    public ArbeidsgiverinitiertDialogRestValiderer(GrunnlagTjeneste grunnlagTjeneste, K9SakTjeneste k9SakTjeneste) {
+    public ArbeidsgiverinitiertDialogRestValiderer(GrunnlagTjeneste grunnlagTjeneste) {
         this.grunnlagTjeneste = grunnlagTjeneste;
-        this.k9SakTjeneste = k9SakTjeneste;
     }
 
     public void validerPerson(PersonInfo personInfo) {

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/ArbeidsgiverinitiertDialogRestValiderer.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/ArbeidsgiverinitiertDialogRestValiderer.java
@@ -12,11 +12,8 @@ import no.nav.familie.inntektsmelding.integrasjoner.k9sak.FagsakInfo;
 import no.nav.familie.inntektsmelding.integrasjoner.k9sak.K9SakTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonInfo;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
-import no.nav.familie.inntektsmelding.typer.dto.KodeverkMapper;
 import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
 import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
-import no.nav.familie.inntektsmelding.typer.dto.YtelseTypeDto;
-import no.nav.k9.sak.typer.AktørId;
 import no.nav.vedtak.exception.FunksjonellException;
 
 @Dependent
@@ -50,23 +47,35 @@ public class ArbeidsgiverinitiertDialogRestValiderer {
         }
     }
 
-    public void validerSakIK9(PersonInfo personInfo, YtelseTypeDto ytelseType, LocalDate førsteFraværsdag) {
-        // Sjekk at søker har sak i k9-sak
-        Ytelsetype ytelsetype = KodeverkMapper.mapYtelsetype(ytelseType);
-        AktørId aktørId = new AktørId(personInfo.aktørId().getAktørId());
-        List<FagsakInfo> fagsakerIK9Sak =  k9SakTjeneste.hentFagsakInfo(ytelsetype, aktørId);
-        List<PeriodeDto> søknadsPerioderForFagsakerIK9 = fagsakerIK9Sak.stream()
+    public void validerAtFraværsdatoTrefferEnSøknadsperiodeIK9(LocalDate førsteFraværsdag, List<FagsakInfo> fagsakerIK9, Ytelsetype ytelsetype) {
+        List<PeriodeDto> søknadsPerioderForFagsakerIK9 = fagsakerIK9.stream()
             .flatMap(fagsak -> fagsak.søknadsPerioder().stream())
             .toList();
 
-        var finnesSakIK9 = søknadsPerioderForFagsakerIK9.stream()
+        boolean fraværsdagErInnenforSøknadsperiode = søknadsPerioderForFagsakerIK9.stream()
             .anyMatch(søknandsperiode -> søknandsperiode.inneholderDato(førsteFraværsdag));
 
-        if (!finnesSakIK9) {
+        if (!fraværsdagErInnenforSøknadsperiode) {
             var feilmelding = String.format("Du kan ikke sende inn inntektsmelding på %s for denne personen", ytelsetype);
             throw new FunksjonellException("INGEN_SAK_FUNNET", feilmelding, null, null);
         }
+    }
 
+    public void validerAtFraværsdatoErFørsteFraværsdagISøknadsperiode(LocalDate førsteFraværsdag, List<FagsakInfo> fagsakerIK9, Ytelsetype ytelsetype) {
+        List<PeriodeDto> søknadsPerioderForFagsakerIK9 = fagsakerIK9.stream()
+            .flatMap(fagsak -> fagsak.søknadsPerioder().stream())
+            .toList();
+
+        boolean erFørsteFraværsdag = søknadsPerioderForFagsakerIK9.stream()
+            .anyMatch(søknandsperiode -> søknandsperiode.fom().isEqual(førsteFraværsdag));
+
+        if (!erFørsteFraværsdag) {
+            var feilmelding = String.format("Du kan ikke sende inn inntektsmelding på %s for denne personen", ytelsetype);
+            throw new FunksjonellException("INGEN_SAK_FUNNET", feilmelding, null, null);
+        }
+    }
+
+    public void validerAtSakIkkeVenterPåForTidligSøknad(List<FagsakInfo> fagsakerIK9Sak, Ytelsetype ytelsetype) {
         if (fagsakerIK9Sak.stream().anyMatch(FagsakInfo::venterForTidligSøknad)) {
             var feilmelding = String.format("Du kan ikke sende inn inntektsmelding før fire uker før denne personen starter med %s", ytelsetype);
             throw new FunksjonellException("SENDT_FOR_TIDLIG", feilmelding, null, null);

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
@@ -20,6 +20,8 @@ import no.nav.familie.inntektsmelding.imdialog.rest.HentArbeidsforholdResponse;
 import no.nav.familie.inntektsmelding.imdialog.rest.HentOpplysningerResponse;
 import no.nav.familie.inntektsmelding.imdialog.rest.OrganisasjonDto;
 import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.InntektTjeneste;
+import no.nav.familie.inntektsmelding.integrasjoner.k9sak.FagsakInfo;
+import no.nav.familie.inntektsmelding.integrasjoner.k9sak.K9SakTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.OrganisasjonTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonInfo;
@@ -37,6 +39,7 @@ import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonInfoDto;
 import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
 import no.nav.familie.inntektsmelding.typer.dto.PersonInfoDto;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
+import no.nav.k9.sak.typer.AktørId;
 import no.nav.vedtak.sikkerhet.kontekst.IdentType;
 import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
 
@@ -51,6 +54,7 @@ public class GrunnlagTjeneste {
     private InntektTjeneste inntektTjeneste;
     private ArbeidstakerTjeneste arbeidstakerTjeneste;
     private ArbeidsforholdTjeneste arbeidsforholdTjeneste;
+    private K9SakTjeneste k9SakTjeneste;
 
     GrunnlagTjeneste() {
     }
@@ -61,13 +65,14 @@ public class GrunnlagTjeneste {
                             OrganisasjonTjeneste organisasjonTjeneste,
                             InntektTjeneste inntektTjeneste,
                             ArbeidstakerTjeneste arbeidstakerTjeneste,
-                            ArbeidsforholdTjeneste arbeidsforholdTjeneste) {
+                            ArbeidsforholdTjeneste arbeidsforholdTjeneste, K9SakTjeneste k9SakTjeneste) {
         this.forespørselBehandlingTjeneste = forespørselBehandlingTjeneste;
         this.personTjeneste = personTjeneste;
         this.organisasjonTjeneste = organisasjonTjeneste;
         this.inntektTjeneste = inntektTjeneste;
         this.arbeidstakerTjeneste = arbeidstakerTjeneste;
         this.arbeidsforholdTjeneste = arbeidsforholdTjeneste;
+        this.k9SakTjeneste = k9SakTjeneste;
     }
 
     public HentOpplysningerResponse hentOpplysninger(UUID forespørselUuid) {
@@ -134,6 +139,11 @@ public class GrunnlagTjeneste {
             forespørselType,
             førsteFraværsdag,
             null);
+    }
+
+    public List<FagsakInfo> hentFagsakerIK9(PersonInfo personInfo, Ytelsetype ytelseType) {
+        AktørId aktørId = new AktørId(personInfo.aktørId().getAktørId());
+        return k9SakTjeneste.hentFagsakInfo(ytelseType, aktørId);
     }
 
     private boolean innenforIntervall(LocalDate nyFørsteFraværsdag, LocalDate eksisterendeForespørselStp) {

--- a/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjenesteTest.java
@@ -23,6 +23,7 @@ import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselMapper;
 import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.InntektTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.Inntektsopplysninger;
+import no.nav.familie.inntektsmelding.integrasjoner.k9sak.K9SakTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.Organisasjon;
 import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.OrganisasjonTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
@@ -64,6 +65,8 @@ class GrunnlagTjenesteTest {
     private ArbeidstakerTjeneste arbeidstakerTjeneste;
     @Mock
     private ArbeidsforholdTjeneste arbeidsforholdTjeneste;
+    @Mock
+    private K9SakTjeneste k9SakTjeneste;
 
 
     private GrunnlagTjeneste grunnlagTjeneste;
@@ -81,7 +84,7 @@ class GrunnlagTjenesteTest {
 
     @BeforeEach
     void setUp() {
-        grunnlagTjeneste = new GrunnlagTjeneste(forespørselBehandlingTjeneste, personTjeneste, organisasjonTjeneste, inntektTjeneste, arbeidstakerTjeneste, arbeidsforholdTjeneste);
+        grunnlagTjeneste = new GrunnlagTjeneste(forespørselBehandlingTjeneste, personTjeneste, organisasjonTjeneste, inntektTjeneste, arbeidstakerTjeneste, arbeidsforholdTjeneste, k9SakTjeneste);
     }
 
     @Test


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi ønsker strengere validering for uregistrerte slik at første fraværsdag må treffe første dag i søknadsperiode. Dette fordi inntektsmeldinger som ikke treffer STP blir filtrert ut i k9.

Jira: https://jira.adeo.no/browse/TSFF-2580

### **Løsning**
- Flytter logikk for henting av sak til grunnlagtjenesten.
- Splitter `validerSakIK9` i flere midre valideringer.

### **Andre endringer**
- Sletter deprecated endepunkt hentArbeidsforhold og hentOpplysninger som ikke lenger er i bruk.
- Legger til nytt endepunkt som kun henter arbeidstakers personopplysninger. Dette fordi det gamle hentArbeidsgivereUregistrert legger til arbeidsgivers organisasjoner (noe som ikke gir helt mening. Eget endepunkt for å hente orgnummer for arbeidsgiver ble lagt til her: https://github.com/navikt/k9-inntektsmelding/pull/667)

