### PR TITLE
TSFF-2579: Hent etterspurte perioder ved henting av opplysninger for uregistrert inntektsmelding omsorgspenger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <prosesstask.version>5.2.5</prosesstask.version>
         <fp-kontrakter.version>9.4.30</fp-kontrakter.version>
         <k9-felles.version>10.6.2</k9-felles.version>
-        <k9-sak.version>6.0.13</k9-sak.version>
+        <k9-sak.version>7.0.2</k9-sak.version>
         <sif-abac-kontrakt.version>1.9.0</sif-abac-kontrakt.version>
     </properties>
 

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
@@ -41,7 +41,6 @@ import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
 import no.nav.familie.inntektsmelding.typer.dto.PersonInfoDto;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
 import no.nav.k9.sak.typer.AktørId;
-import no.nav.k9.sak.typer.Periode;
 import no.nav.vedtak.sikkerhet.kontekst.IdentType;
 import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
 
@@ -169,15 +168,13 @@ public class GrunnlagTjeneste {
             return null;
         }
 
-        Set<Periode> etterspurtePerioderForOrganisasjon = relevantFagsak.arbeidsgiverMedEtterspurtePerioder().get(organisasjonsnummer.orgnr());
+        Set<PeriodeDto> etterspurtePerioderForOrganisasjon = relevantFagsak.arbeidsgiverMedEtterspurtePerioder().get(organisasjonsnummer.orgnr());
         if (etterspurtePerioderForOrganisasjon == null) {
             LOG.warn("Fant ingen etterspurte perioder for organisasjonsnummer {}.", organisasjonsnummer.orgnr());
             return null;
         }
 
-        return etterspurtePerioderForOrganisasjon.stream()
-            .map(p -> new PeriodeDto(p.getFom(), p.getTom()))
-            .toList();
+        return etterspurtePerioderForOrganisasjon.stream().toList();
     }
 
     private boolean innenforIntervall(LocalDate nyFørsteFraværsdag, LocalDate eksisterendeForespørselStp) {

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
@@ -148,7 +148,7 @@ public class GrunnlagTjeneste {
             etterspurtePerioder);
     }
 
-    public List<FagsakInfo> hentFagsakerIK9(PersonInfo personInfo, Ytelsetype ytelseType) {
+    private List<FagsakInfo> hentFagsakerIK9(PersonInfo personInfo, Ytelsetype ytelseType) {
         AktørId aktørId = new AktørId(personInfo.aktørId().getAktørId());
         return k9SakTjeneste.hentFagsakInfo(ytelseType, aktørId);
     }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
@@ -20,6 +20,8 @@ import no.nav.familie.inntektsmelding.imdialog.rest.HentArbeidsforholdResponse;
 import no.nav.familie.inntektsmelding.imdialog.rest.HentOpplysningerResponse;
 import no.nav.familie.inntektsmelding.imdialog.rest.OrganisasjonDto;
 import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.InntektTjeneste;
+import no.nav.familie.inntektsmelding.integrasjoner.k9sak.FagsakInfo;
+import no.nav.familie.inntektsmelding.integrasjoner.k9sak.K9SakTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.OrganisasjonTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonInfo;
@@ -35,8 +37,11 @@ import no.nav.familie.inntektsmelding.typer.dto.KodeverkMapper;
 import no.nav.familie.inntektsmelding.typer.dto.MånedsinntektDto;
 import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonInfoDto;
 import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
+import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
 import no.nav.familie.inntektsmelding.typer.dto.PersonInfoDto;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
+import no.nav.k9.sak.typer.AktørId;
+import no.nav.k9.sak.typer.Periode;
 import no.nav.vedtak.sikkerhet.kontekst.IdentType;
 import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
 
@@ -51,6 +56,7 @@ public class GrunnlagTjeneste {
     private InntektTjeneste inntektTjeneste;
     private ArbeidstakerTjeneste arbeidstakerTjeneste;
     private ArbeidsforholdTjeneste arbeidsforholdTjeneste;
+    private K9SakTjeneste k9SakTjeneste;
 
     GrunnlagTjeneste() {
     }
@@ -61,13 +67,15 @@ public class GrunnlagTjeneste {
                             OrganisasjonTjeneste organisasjonTjeneste,
                             InntektTjeneste inntektTjeneste,
                             ArbeidstakerTjeneste arbeidstakerTjeneste,
-                            ArbeidsforholdTjeneste arbeidsforholdTjeneste) {
+                            ArbeidsforholdTjeneste arbeidsforholdTjeneste,
+                            K9SakTjeneste k9SakTjeneste) {
         this.forespørselBehandlingTjeneste = forespørselBehandlingTjeneste;
         this.personTjeneste = personTjeneste;
         this.organisasjonTjeneste = organisasjonTjeneste;
         this.inntektTjeneste = inntektTjeneste;
         this.arbeidstakerTjeneste = arbeidstakerTjeneste;
         this.arbeidsforholdTjeneste = arbeidsforholdTjeneste;
+        this.k9SakTjeneste = k9SakTjeneste;
     }
 
     public HentOpplysningerResponse hentOpplysninger(UUID forespørselUuid) {
@@ -123,6 +131,11 @@ public class GrunnlagTjeneste {
         var innsender = finnInnsender();
         var inntektsopplysninger = finnInntektsopplysninger(null, personInfo.aktørId(), førsteFraværsdag, organisasjonsnummer.orgnr(), ytelsetype);
 
+        List<PeriodeDto> etterspurtePerioder = null;
+        if (Ytelsetype.OMSORGSPENGER.equals(ytelsetype) && ForespørselType.ARBEIDSGIVERINITIERT_UREGISTRERT.equals(forespørselType)) {
+            etterspurtePerioder = hentEtterspurtePerioder(personInfo, ytelsetype, førsteFraværsdag, organisasjonsnummer);
+        }
+
         return new HentOpplysningerResponse(lagPersonInfoDto(personInfo),
             organisasjonInfo,
             innsender,
@@ -133,7 +146,38 @@ public class GrunnlagTjeneste {
             KodeverkMapper.mapForespørselStatus(ForespørselStatus.UNDER_BEHANDLING),
             forespørselType,
             førsteFraværsdag,
-            null);
+            etterspurtePerioder);
+    }
+
+    public List<FagsakInfo> hentFagsakerIK9(PersonInfo personInfo, Ytelsetype ytelseType) {
+        AktørId aktørId = new AktørId(personInfo.aktørId().getAktørId());
+        return k9SakTjeneste.hentFagsakInfo(ytelseType, aktørId);
+    }
+
+    private List<PeriodeDto> hentEtterspurtePerioder(PersonInfo personInfo,
+                                                     Ytelsetype ytelsetype,
+                                                     LocalDate førsteFraværsdag,
+                                                     OrganisasjonsnummerDto organisasjonsnummer) {
+        List<FagsakInfo> fagsaker = hentFagsakerIK9(personInfo, ytelsetype);
+        FagsakInfo relevantFagsak = fagsaker.stream()
+            .filter(f -> f.søknadsPerioder().stream().anyMatch(p -> p.inneholderDato(førsteFraværsdag)))
+            .findFirst()
+            .orElse(null);
+
+        if (relevantFagsak == null || relevantFagsak.arbeidsgiverMedEtterspurtePerioder() == null) {
+            LOG.warn("Fant ingen relevant fagsak ved henting av etterspurte perioder.");
+            return null;
+        }
+
+        Set<Periode> etterspurtePerioderForOrganisasjon = relevantFagsak.arbeidsgiverMedEtterspurtePerioder().get(organisasjonsnummer.orgnr());
+        if (etterspurtePerioderForOrganisasjon == null) {
+            LOG.warn("Fant ingen etterspurte perioder for organisasjonsnummer {}.", organisasjonsnummer.orgnr());
+            return null;
+        }
+
+        return etterspurtePerioderForOrganisasjon.stream()
+            .map(p -> new PeriodeDto(p.getFom(), p.getTom()))
+            .toList();
     }
 
     private boolean innenforIntervall(LocalDate nyFørsteFraværsdag, LocalDate eksisterendeForespørselStp) {

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
@@ -165,13 +165,13 @@ public class GrunnlagTjeneste {
 
         if (relevantFagsak == null || relevantFagsak.arbeidsgiverMedEtterspurtePerioder() == null) {
             LOG.warn("Fant ingen relevant fagsak ved henting av etterspurte perioder.");
-            return null;
+            return List.of();
         }
 
         Set<PeriodeDto> etterspurtePerioderForOrganisasjon = relevantFagsak.arbeidsgiverMedEtterspurtePerioder().get(organisasjonsnummer.orgnr());
         if (etterspurtePerioderForOrganisasjon == null) {
             LOG.warn("Fant ingen etterspurte perioder for organisasjonsnummer {}.", organisasjonsnummer.orgnr());
-            return null;
+            return List.of();
         }
 
         return etterspurtePerioderForOrganisasjon.stream()

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
@@ -174,7 +174,9 @@ public class GrunnlagTjeneste {
             return null;
         }
 
-        return etterspurtePerioderForOrganisasjon.stream().toList();
+        return etterspurtePerioderForOrganisasjon.stream()
+            .sorted(Comparator.comparing(PeriodeDto::fom).thenComparing(PeriodeDto::tom))
+            .toList();
     }
 
     private boolean innenforIntervall(LocalDate nyFørsteFraværsdag, LocalDate eksisterendeForespørselStp) {

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/FagsakInfo.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/FagsakInfo.java
@@ -8,13 +8,12 @@ import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
 import no.nav.familie.inntektsmelding.typer.dto.SaksnummerDto;
 import no.nav.k9.sak.typer.AktørId;
-import no.nav.k9.sak.typer.Periode;
 
 public record FagsakInfo(SaksnummerDto saksnummer,
                          Ytelsetype ytelseType,
                          AktørId aktørId,
                          PeriodeDto gyldigPeriode,
                          List<PeriodeDto> søknadsPerioder,
-                         Map<String, Set<Periode>> arbeidsgiverMedEtterspurtePerioder,
+                         Map<String, Set<PeriodeDto>> arbeidsgiverMedEtterspurtePerioder,
                          boolean venterForTidligSøknad) {
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/FagsakInfo.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/FagsakInfo.java
@@ -1,16 +1,20 @@
 package no.nav.familie.inntektsmelding.integrasjoner.k9sak;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
 import no.nav.familie.inntektsmelding.typer.dto.SaksnummerDto;
 import no.nav.k9.sak.typer.AktørId;
+import no.nav.k9.sak.typer.Periode;
 
 public record FagsakInfo(SaksnummerDto saksnummer,
                          Ytelsetype ytelseType,
                          AktørId aktørId,
                          PeriodeDto gyldigPeriode,
                          List<PeriodeDto> søknadsPerioder,
+                         Map<String, Set<Periode>> arbeidsgiverMedEtterspurtePerioder,
                          boolean venterForTidligSøknad) {
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/K9SakTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/K9SakTjeneste.java
@@ -34,6 +34,7 @@ public class K9SakTjeneste {
             k9Fagsak.aktørId(),
             new PeriodeDto(k9Fagsak.gyldigPeriode().getFom(), k9Fagsak.gyldigPeriode().getTom()),
             mapSøknadsperiode(k9Fagsak),
+            k9Fagsak.arbeidsgiverMedEtterspurtePerioder(),
             k9Fagsak.venterForTidligSøknad());
     }
 
@@ -48,6 +49,7 @@ public class K9SakTjeneste {
                     k9Fagsak.aktørId(),
                     new PeriodeDto(k9Fagsak.gyldigPeriode().getFom(), k9Fagsak.gyldigPeriode().getTom()),
                     mapSøknadsperiode(k9Fagsak),
+                    k9Fagsak.arbeidsgiverMedEtterspurtePerioder(),
                     k9Fagsak.venterForTidligSøknad()
                 )
             ).toList();

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/K9SakTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/k9sak/K9SakTjeneste.java
@@ -1,6 +1,10 @@
 package no.nav.familie.inntektsmelding.integrasjoner.k9sak;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -11,6 +15,7 @@ import no.nav.familie.inntektsmelding.typer.dto.SaksnummerDto;
 import no.nav.k9.kodeverk.behandling.FagsakYtelseType;
 import no.nav.k9.sak.kontrakt.k9inntektsmelding.FinnSakerDto;
 import no.nav.k9.sak.typer.AktørId;
+import no.nav.k9.sak.typer.Periode;
 
 @ApplicationScoped
 public class K9SakTjeneste {
@@ -34,7 +39,7 @@ public class K9SakTjeneste {
             k9Fagsak.aktørId(),
             new PeriodeDto(k9Fagsak.gyldigPeriode().getFom(), k9Fagsak.gyldigPeriode().getTom()),
             mapSøknadsperiode(k9Fagsak),
-            k9Fagsak.arbeidsgiverMedEtterspurtePerioder(),
+            mapEtterspurtePerioder(k9Fagsak.arbeidsgiverMedEtterspurtePerioder()),
             k9Fagsak.venterForTidligSøknad());
     }
 
@@ -49,7 +54,7 @@ public class K9SakTjeneste {
                     k9Fagsak.aktørId(),
                     new PeriodeDto(k9Fagsak.gyldigPeriode().getFom(), k9Fagsak.gyldigPeriode().getTom()),
                     mapSøknadsperiode(k9Fagsak),
-                    k9Fagsak.arbeidsgiverMedEtterspurtePerioder(),
+                    mapEtterspurtePerioder(k9Fagsak.arbeidsgiverMedEtterspurtePerioder()),
                     k9Fagsak.venterForTidligSøknad()
                 )
             ).toList();
@@ -60,6 +65,22 @@ public class K9SakTjeneste {
             .stream()
             .map(søknadsPeriode -> new PeriodeDto(søknadsPeriode.getFom(), søknadsPeriode.getTom()))
             .toList();
+    }
+
+    private static Map<String, Set<PeriodeDto>> mapEtterspurtePerioder(Map<String, Set<Periode>> etterspurtePerioder) {
+        if (etterspurtePerioder == null) {
+            return null;
+        }
+
+        var resultat = new HashMap<String, Set<PeriodeDto>>();
+        for (var entry : etterspurtePerioder.entrySet()) {
+            var perioder = new HashSet<PeriodeDto>();
+            for (var periode : entry.getValue()) {
+                perioder.add(new PeriodeDto(periode.getFom(), periode.getTom()));
+            }
+            resultat.put(entry.getKey(), perioder);
+        }
+        return resultat;
     }
 
     private Ytelsetype mapYtelsetype(FagsakYtelseType fagsagYtelseType) {

--- a/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjenesteTest.java
@@ -46,7 +46,6 @@ import no.nav.familie.inntektsmelding.typer.dto.SaksnummerDto;
 import no.nav.familie.inntektsmelding.typer.dto.YtelseTypeDto;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
 import no.nav.k9.sak.typer.AktørId;
-import no.nav.k9.sak.typer.Periode;
 import no.nav.vedtak.sikkerhet.kontekst.IdentType;
 import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
 import no.nav.vedtak.sikkerhet.kontekst.RequestKontekst;
@@ -389,10 +388,10 @@ class GrunnlagTjenesteTest {
         when(inntektTjeneste.hentInntekt(aktørId, førsteFraværsdag, LocalDate.now(), organisasjonsnummer.orgnr(), ytelsetype))
             .thenReturn(new Inntektsopplysninger(BigDecimal.valueOf(52000), organisasjonsnummer.orgnr(), List.of()));
 
-        var etterspurtPeriode1 = new Periode(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 6, 30));
-        var etterspurtPeriode2 = new Periode(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 31));
+        var etterspurtPeriode1 = new PeriodeDto(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 6, 30));
+        var etterspurtPeriode2 = new PeriodeDto(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 31));
         var annenOrganisasjonsnummer = "888888888";
-        var etterspurtPeriodeAnnenOrg = new Periode(LocalDate.of(2024, 9, 1), LocalDate.of(2024, 9, 30));
+        var etterspurtPeriodeAnnenOrg = new PeriodeDto(LocalDate.of(2024, 9, 1), LocalDate.of(2024, 9, 30));
         var fagsakInfo = new FagsakInfo(
             new SaksnummerDto("123"),
             ytelsetype,
@@ -440,7 +439,7 @@ class GrunnlagTjenesteTest {
             new AktørId(aktørId.getAktørId()),
             new PeriodeDto(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31)),
             List.of(new PeriodeDto(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 6, 30))),
-            Map.of(organisasjonsnummer.orgnr(), Set.of(new Periode(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 6, 30)))),
+            Map.of(organisasjonsnummer.orgnr(), Set.of(new PeriodeDto(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 6, 30)))),
             false);
         when(k9SakTjeneste.hentFagsakInfo(ytelsetype, new AktørId(aktørId.getAktørId()))).thenReturn(List.of(fagsakInfo));
 

--- a/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjenesteTest.java
@@ -7,6 +7,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -23,6 +24,8 @@ import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselMapper;
 import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.InntektTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.Inntektsopplysninger;
+import no.nav.familie.inntektsmelding.integrasjoner.k9sak.FagsakInfo;
+import no.nav.familie.inntektsmelding.integrasjoner.k9sak.K9SakTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.Organisasjon;
 import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.OrganisasjonTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
@@ -38,8 +41,12 @@ import no.nav.familie.inntektsmelding.typer.dto.Kjønn;
 import no.nav.familie.inntektsmelding.typer.dto.MånedsinntektDto;
 import no.nav.familie.inntektsmelding.typer.dto.MånedslønnStatus;
 import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
+import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
+import no.nav.familie.inntektsmelding.typer.dto.SaksnummerDto;
 import no.nav.familie.inntektsmelding.typer.dto.YtelseTypeDto;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
+import no.nav.k9.sak.typer.AktørId;
+import no.nav.k9.sak.typer.Periode;
 import no.nav.vedtak.sikkerhet.kontekst.IdentType;
 import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
 import no.nav.vedtak.sikkerhet.kontekst.RequestKontekst;
@@ -64,6 +71,8 @@ class GrunnlagTjenesteTest {
     private ArbeidstakerTjeneste arbeidstakerTjeneste;
     @Mock
     private ArbeidsforholdTjeneste arbeidsforholdTjeneste;
+    @Mock
+    private K9SakTjeneste k9SakTjeneste;
 
 
     private GrunnlagTjeneste grunnlagTjeneste;
@@ -81,7 +90,7 @@ class GrunnlagTjenesteTest {
 
     @BeforeEach
     void setUp() {
-        grunnlagTjeneste = new GrunnlagTjeneste(forespørselBehandlingTjeneste, personTjeneste, organisasjonTjeneste, inntektTjeneste, arbeidstakerTjeneste, arbeidsforholdTjeneste);
+        grunnlagTjeneste = new GrunnlagTjeneste(forespørselBehandlingTjeneste, personTjeneste, organisasjonTjeneste, inntektTjeneste, arbeidstakerTjeneste, arbeidsforholdTjeneste, k9SakTjeneste);
     }
 
     @Test
@@ -360,5 +369,86 @@ class GrunnlagTjenesteTest {
         assertThat(imDialogDto.førsteUttaksdato()).isEqualTo(førsteFraværsdag);
         assertThat(imDialogDto.inntektsopplysninger().gjennomsnittLønn()).isEqualByComparingTo(BigDecimal.valueOf(52000));
         assertThat(imDialogDto.forespørselUuid()).isEqualTo(null);
+    }
+
+    @Test
+    void skal_hente_etterspurte_perioder_for_omsorgspenger_uregistrert() {
+        // Arrange
+        var fødselsnummer = new PersonIdent("11111111111");
+        var ytelsetype = Ytelsetype.OMSORGSPENGER;
+        var førsteFraværsdag = LocalDate.of(2024, 6, 15);
+        var organisasjonsnummer = new OrganisasjonsnummerDto("999999999");
+        var aktørId = new AktørIdEntitet("9999999999999");
+        var personInfo = new PersonInfo("Navn", null, "Navnesen", fødselsnummer, aktørId, LocalDate.now(), null, Kjønn.KVINNE);
+
+        when(personTjeneste.hentPersonFraIdent(fødselsnummer)).thenReturn(personInfo);
+        when(personTjeneste.hentPersonFraIdent(PersonIdent.fra(INNMELDER_UID))).thenReturn(
+            new PersonInfo("Ine", null, "Sender", new PersonIdent(INNMELDER_UID), null, LocalDate.now(), "+4711111111", Kjønn.KVINNE));
+        when(forespørselBehandlingTjeneste.finnAlleForespørsler(aktørId, ytelsetype, organisasjonsnummer.orgnr())).thenReturn(List.of());
+        when(organisasjonTjeneste.finnOrganisasjon(organisasjonsnummer.orgnr())).thenReturn(new Organisasjon("Bedriften", organisasjonsnummer.orgnr()));
+        when(inntektTjeneste.hentInntekt(aktørId, førsteFraværsdag, LocalDate.now(), organisasjonsnummer.orgnr(), ytelsetype))
+            .thenReturn(new Inntektsopplysninger(BigDecimal.valueOf(52000), organisasjonsnummer.orgnr(), List.of()));
+
+        var etterspurtPeriode1 = new Periode(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 6, 30));
+        var etterspurtPeriode2 = new Periode(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 31));
+        var annenOrganisasjonsnummer = "888888888";
+        var etterspurtPeriodeAnnenOrg = new Periode(LocalDate.of(2024, 9, 1), LocalDate.of(2024, 9, 30));
+        var fagsakInfo = new FagsakInfo(
+            new SaksnummerDto("123"),
+            ytelsetype,
+            new AktørId(aktørId.getAktørId()),
+            new PeriodeDto(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31)),
+            List.of(new PeriodeDto(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 6, 30))),
+            Map.of(organisasjonsnummer.orgnr(), Set.of(etterspurtPeriode1, etterspurtPeriode2),
+                annenOrganisasjonsnummer, Set.of(etterspurtPeriodeAnnenOrg)),
+            false);
+        when(k9SakTjeneste.hentFagsakInfo(ytelsetype, new AktørId(aktørId.getAktørId()))).thenReturn(List.of(fagsakInfo));
+
+        // Act
+        var opplysninger = grunnlagTjeneste.hentOpplysninger(fødselsnummer, ytelsetype, førsteFraværsdag, organisasjonsnummer, ForespørselType.ARBEIDSGIVERINITIERT_UREGISTRERT);
+
+        // Assert
+        assertThat(opplysninger.forespørselUuid()).isNull();
+        assertThat(opplysninger.etterspurtePerioder()).isNotNull();
+        assertThat(opplysninger.etterspurtePerioder()).hasSize(2);
+        assertThat(opplysninger.etterspurtePerioder()).contains(new PeriodeDto(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 6, 30)));
+        assertThat(opplysninger.etterspurtePerioder()).contains(new PeriodeDto(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 31)));
+        assertThat(opplysninger.etterspurtePerioder()).doesNotContain(new PeriodeDto(LocalDate.of(2024, 9, 1), LocalDate.of(2024, 9, 30)));
+    }
+
+    @Test
+    void skal_returnere_null_etterspurte_perioder_når_søknadsperiode_ikke_inneholder_første_fraværsdag() {
+        // Arrange
+        var fødselsnummer = new PersonIdent("11111111111");
+        var ytelsetype = Ytelsetype.OMSORGSPENGER;
+        var førsteFraværsdag = LocalDate.of(2024, 8, 15);
+        var organisasjonsnummer = new OrganisasjonsnummerDto("999999999");
+        var aktørId = new AktørIdEntitet("9999999999999");
+        var personInfo = new PersonInfo("Navn", null, "Navnesen", fødselsnummer, aktørId, LocalDate.now(), null, Kjønn.KVINNE);
+
+        when(personTjeneste.hentPersonFraIdent(fødselsnummer)).thenReturn(personInfo);
+        when(personTjeneste.hentPersonFraIdent(PersonIdent.fra(INNMELDER_UID))).thenReturn(
+            new PersonInfo("Ine", null, "Sender", new PersonIdent(INNMELDER_UID), null, LocalDate.now(), "+4711111111", Kjønn.KVINNE));
+        when(forespørselBehandlingTjeneste.finnAlleForespørsler(aktørId, ytelsetype, organisasjonsnummer.orgnr())).thenReturn(List.of());
+        when(organisasjonTjeneste.finnOrganisasjon(organisasjonsnummer.orgnr())).thenReturn(new Organisasjon("Bedriften", organisasjonsnummer.orgnr()));
+        when(inntektTjeneste.hentInntekt(aktørId, førsteFraværsdag, LocalDate.now(), organisasjonsnummer.orgnr(), ytelsetype))
+            .thenReturn(new Inntektsopplysninger(BigDecimal.valueOf(52000), organisasjonsnummer.orgnr(), List.of()));
+
+        var fagsakInfo = new FagsakInfo(
+            new SaksnummerDto("123"),
+            ytelsetype,
+            new AktørId(aktørId.getAktørId()),
+            new PeriodeDto(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31)),
+            List.of(new PeriodeDto(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 6, 30))),
+            Map.of(organisasjonsnummer.orgnr(), Set.of(new Periode(LocalDate.of(2024, 6, 1), LocalDate.of(2024, 6, 30)))),
+            false);
+        when(k9SakTjeneste.hentFagsakInfo(ytelsetype, new AktørId(aktørId.getAktørId()))).thenReturn(List.of(fagsakInfo));
+
+        // Act
+        var opplysninger = grunnlagTjeneste.hentOpplysninger(fødselsnummer, ytelsetype, førsteFraværsdag, organisasjonsnummer, ForespørselType.ARBEIDSGIVERINITIERT_UREGISTRERT);
+
+        // Assert
+        assertThat(opplysninger.forespørselUuid()).isNull();
+        assertThat(opplysninger.etterspurtePerioder()).isNull();
     }
 }

--- a/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjenesteTest.java
@@ -448,6 +448,6 @@ class GrunnlagTjenesteTest {
 
         // Assert
         assertThat(opplysninger.forespørselUuid()).isNull();
-        assertThat(opplysninger.etterspurtePerioder()).isNull();
+        assertThat(opplysninger.etterspurtePerioder()).isEmpty();
     }
 }


### PR DESCRIPTION
### **Behov / Bakgrunn**
For inntektsmelding omsorgspenger for uregistrerte trenger vi å vise hvilke perioder k9 ønsker å få inn.

Jira: https://jira.adeo.no/browse/TSFF-2579

### **Løsning**
- Kaller hent fagsaker i k9 for å hente etterspurte perioder. 
- Bruker fagsak som hvor søknadsperiode inneholder første fraværsdag. 
- Henter kun etterspurte periode for oppgitt orgnummer.
