### PR TITLE
Erstatter ikke-godkjente fødselsnummer med fiktive FNR fra godkjent liste

### DIFF
--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRestTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRestTest.java
@@ -42,7 +42,7 @@ class RefusjonOmsorgsdagerRestTest {
         var fnr = PersonIdent.fra("12345678910");
         var request = new SlåOppArbeidstakerRequest(fnr, Ytelsetype.OMSORGSPENGER);
         var arbeidsforhold = List.of(new SlåOppArbeidstakerResponse.ArbeidsforholdDto("999999999", "Arbeidsgiver AS"));
-        var arbeidstakerInfo = new SlåOppArbeidstakerResponse(new SlåOppArbeidstakerResponse.Personinformasjon("fornavn", "mellomnavn", "etternavn", "10107400090", "12345"), arbeidsforhold);
+        var arbeidstakerInfo = new SlåOppArbeidstakerResponse(new SlåOppArbeidstakerResponse.Personinformasjon("fornavn", "mellomnavn", "etternavn", "01017000299", "12345"), arbeidsforhold);
 
         when(refusjonOmsorgsdagerServiceMock.hentArbeidstaker(fnr)).thenReturn(arbeidstakerInfo);
 

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/ArbeidstakerTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/ArbeidstakerTjenesteTest.java
@@ -22,7 +22,7 @@ import no.nav.vedtak.konfig.Tid;
 @ExtendWith(MockitoExtension.class)
 class ArbeidstakerTjenesteTest {
 
-    private static final PersonIdent TILFELDIG_PERSON_IDENT = PersonIdent.fra("21073926618");
+    private static final PersonIdent TILFELDIG_PERSON_IDENT = PersonIdent.fra("01017000299");
 
     @Mock
     private ArbeidsforholdTjeneste arbeidsforholdTjenesteMock;


### PR DESCRIPTION
## Erstatter ikke-godkjente fødselsnummer

Bytter ut fødselsnummer som ikke er på [godkjent liste](https://github.com/navikt/sif-gha-workflows/tree/main/.github/actions/sif-code-scan/allowed-fnr) med fiktive fødselsnummer fra sif-gha-workflows allowed-fnr.

Dette sikrer at `sif-code-scan` ikke feiler i CI/CD-pipeline.