### PR TITLE
TSFF-2609 hent underenhet for organisasjoner 

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/altinn/AltinnTilgangTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/altinn/AltinnTilgangTjeneste.java
@@ -64,8 +64,8 @@ public class AltinnTilgangTjeneste {
         var organisasjoner = altinnKlient.hentTilganger().hierarki();
         var underenheter = finnUnderenheter(organisasjoner);
 
-        var orgNrMedGittTilgangIAltinn2 = hentOrgNrMedTilgang(underenheter, AltinnRessurser.ALTINN_TO_TJENESTE);
-        var orgNrMedGittTilgangIAltinn3 = hentOrgNrMedTilgang(underenheter, AltinnRessurser.ALTINN_TRE_RESSURS);
+        var orgNrMedGittTilgangIAltinn2 = hentOrgNrMedTilgangAltinn2(underenheter);
+        var orgNrMedGittTilgangIAltinn3 = hentOrgNrMedTilgangAltinn3(underenheter);
 
         var erLik = orgNrMedGittTilgangIAltinn2.equals(orgNrMedGittTilgangIAltinn3);
         if (!erLik) {
@@ -81,13 +81,22 @@ public class AltinnTilgangTjeneste {
         return orgNrMedGittTilgangIAltinn3.stream().toList();
     }
 
-    private static Set<String> hentOrgNrMedTilgang(
-        List<ArbeidsgiverAltinnTilgangerKlient.ArbeidsgiverAltinnTilgangerResponse.Organisasjon> underenheter, String ressurs) {
+    private static Set<String> hentOrgNrMedTilgangAltinn2(List<ArbeidsgiverAltinnTilgangerKlient.ArbeidsgiverAltinnTilgangerResponse.Organisasjon> underenheter) {
         var resultat = new HashSet<String>();
         for (var org : underenheter) {
-            var altinn2 = org.altinn2Tilganger() != null ? org.altinn2Tilganger() : List.<String>of();
-            var altinn3 = org.altinn3Tilganger() != null ? org.altinn3Tilganger() : List.<String>of();
-            if (altinn2.contains(ressurs) || altinn3.contains(ressurs)) {
+            var tilganger = org.altinn2Tilganger() != null ? org.altinn2Tilganger() : List.<String>of();
+            if (tilganger.contains(AltinnRessurser.ALTINN_TO_TJENESTE)) {
+                resultat.add(org.orgnr());
+            }
+        }
+        return resultat;
+    }
+
+    private static Set<String> hentOrgNrMedTilgangAltinn3(List<ArbeidsgiverAltinnTilgangerKlient.ArbeidsgiverAltinnTilgangerResponse.Organisasjon> underenheter) {
+        var resultat = new HashSet<String>();
+        for (var org : underenheter) {
+            var tilganger = org.altinn3Tilganger() != null ? org.altinn3Tilganger() : List.<String>of();
+            if (tilganger.contains(AltinnRessurser.ALTINN_TRE_RESSURS)) {
                 resultat.add(org.orgnr());
             }
         }

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/altinn/AltinnTilgangTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/altinn/AltinnTilgangTjeneste.java
@@ -1,6 +1,7 @@
 package no.nav.familie.inntektsmelding.integrasjoner.altinn;
 
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -60,12 +61,11 @@ public class AltinnTilgangTjeneste {
     }
 
     public List<String> hentBedrifterArbeidsgiverHarTilgangTil() {
+        var organisasjoner = altinnKlient.hentTilganger().hierarki();
+        var underenheter = finnUnderenheter(organisasjoner);
 
-        // TODO: Må ryddes opp etter Altinn 3 ressurs overgang i prod.
-        var orgNrBrukerHarTilgangTilPerRessurs = altinnKlient.hentTilganger().tilgangTilOrgNr();
-
-        var orgNrMedGittTilgangIAltinn2 = hentOrgNrMedGittTilgang(orgNrBrukerHarTilgangTilPerRessurs, AltinnRessurser.ALTINN_TO_TJENESTE);
-        var orgNrMedGittTilgangIAltinn3 = hentOrgNrMedGittTilgang(orgNrBrukerHarTilgangTilPerRessurs, AltinnRessurser.ALTINN_TRE_RESSURS);
+        var orgNrMedGittTilgangIAltinn2 = hentOrgNrMedTilgang(underenheter, AltinnRessurser.ALTINN_TO_TJENESTE);
+        var orgNrMedGittTilgangIAltinn3 = hentOrgNrMedTilgang(underenheter, AltinnRessurser.ALTINN_TRE_RESSURS);
 
         var erLik = orgNrMedGittTilgangIAltinn2.equals(orgNrMedGittTilgangIAltinn3);
         if (!erLik) {
@@ -81,7 +81,32 @@ public class AltinnTilgangTjeneste {
         return orgNrMedGittTilgangIAltinn3.stream().toList();
     }
 
-    private static Set<String> hentOrgNrMedGittTilgang(Map<String, List<String>> orgNrBrukerHarTilgangTilPerRessurs, String ressurs) {
-        return new HashSet<>(orgNrBrukerHarTilgangTilPerRessurs.getOrDefault(ressurs, List.of()));
+    private static Set<String> hentOrgNrMedTilgang(
+        List<ArbeidsgiverAltinnTilgangerKlient.ArbeidsgiverAltinnTilgangerResponse.Organisasjon> underenheter, String ressurs) {
+        var resultat = new HashSet<String>();
+        for (var org : underenheter) {
+            var altinn2 = org.altinn2Tilganger() != null ? org.altinn2Tilganger() : List.<String>of();
+            var altinn3 = org.altinn3Tilganger() != null ? org.altinn3Tilganger() : List.<String>of();
+            if (altinn2.contains(ressurs) || altinn3.contains(ressurs)) {
+                resultat.add(org.orgnr());
+            }
+        }
+        return resultat;
+    }
+
+    private static List<ArbeidsgiverAltinnTilgangerKlient.ArbeidsgiverAltinnTilgangerResponse.Organisasjon> finnUnderenheter(
+        List<ArbeidsgiverAltinnTilgangerKlient.ArbeidsgiverAltinnTilgangerResponse.Organisasjon> organisasjoner) {
+        var underenheter = new ArrayList<ArbeidsgiverAltinnTilgangerKlient.ArbeidsgiverAltinnTilgangerResponse.Organisasjon>();
+        if (organisasjoner == null) {
+            return underenheter;
+        }
+        for (var organisasjon : organisasjoner) {
+            if (organisasjon.underenheter() == null || organisasjon.underenheter().isEmpty()) {
+                underenheter.add(organisasjon);
+            } else {
+                underenheter.addAll(finnUnderenheter(organisasjon.underenheter()));
+            }
+        }
+        return underenheter;
     }
 }

--- a/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/altinn/AltinnTilgangTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/altinn/AltinnTilgangTjenesteTest.java
@@ -17,6 +17,7 @@ class AltinnTilgangTjenesteTest {
 
     private static final String TEST_ORGNR = "999999999";
     private static final String ANNET_ORGNR = "000000000";
+    private static final String JURIDISK_ENHET_ORGNR = "111111111";
 
     @Mock
     ArbeidsgiverAltinnTilgangerKlient altinnKlient;
@@ -70,50 +71,62 @@ class AltinnTilgangTjenesteTest {
 
     @Test
     void hentBedrifter__har_tilgang_via_altinn2_tjeneste() {
-        when(altinnKlient.hentTilganger()).thenReturn(lagTilgangTilOrgNrResponse(AltinnRessurser.ALTINN_TO_TJENESTE, TEST_ORGNR));
+        var underenhet = lagOrganisasjon(TEST_ORGNR, List.of(AltinnRessurser.ALTINN_TO_TJENESTE), List.of(), List.of());
+        var juridiskEnhet = lagOrganisasjon(JURIDISK_ENHET_ORGNR, List.of(), List.of(), List.of(underenhet));
+        when(altinnKlient.hentTilganger()).thenReturn(lagHierarkiResponse(List.of(juridiskEnhet)));
         assertThat(tjeneste.hentBedrifterArbeidsgiverHarTilgangTil()).isNotEmpty().contains(TEST_ORGNR);
     }
 
     @Test
     void hentBedrifter__har_tilgang_via_altinn3_ressurs() {
-        when(altinnKlient.hentTilganger()).thenReturn(lagTilgangTilOrgNrResponse(AltinnRessurser.ALTINN_TRE_RESSURS, TEST_ORGNR));
+        var underenhet = lagOrganisasjon(TEST_ORGNR, List.of(), List.of(AltinnRessurser.ALTINN_TRE_RESSURS), List.of());
+        var juridiskEnhet = lagOrganisasjon(JURIDISK_ENHET_ORGNR, List.of(), List.of(), List.of(underenhet));
+        when(altinnKlient.hentTilganger()).thenReturn(lagHierarkiResponse(List.of(juridiskEnhet)));
         assertThat(tjeneste.hentBedrifterArbeidsgiverHarTilgangTil()).isNotEmpty().contains(TEST_ORGNR);
     }
 
     @Test
     void hentBedrifter__ingen_tilgang_med_annen_ressurs() {
-        when(altinnKlient.hentTilganger()).thenReturn(lagTilgangTilOrgNrResponse("annen_ressurs", TEST_ORGNR));
+        var underenhet = lagOrganisasjon(TEST_ORGNR, List.of("annen_ressurs"), List.of("annen_ressurs"), List.of());
+        var juridiskEnhet = lagOrganisasjon(JURIDISK_ENHET_ORGNR, List.of(), List.of(), List.of(underenhet));
+        when(altinnKlient.hentTilganger()).thenReturn(lagHierarkiResponse(List.of(juridiskEnhet)));
         assertThat(tjeneste.hentBedrifterArbeidsgiverHarTilgangTil()).isEmpty();
     }
 
     @Test
     void hentBedrifter__begge_altinn_versjoner_gir_ingen_duplikater() {
-        when(altinnKlient.hentTilganger()).thenReturn(
-            new ArbeidsgiverAltinnTilgangerKlient.ArbeidsgiverAltinnTilgangerResponse(
-                false, List.of(), null,
-                Map.of(
-                    AltinnRessurser.ALTINN_TO_TJENESTE, List.of(TEST_ORGNR),
-                    AltinnRessurser.ALTINN_TRE_RESSURS, List.of(TEST_ORGNR)
-                )
-            )
-        );
+        var underenhet = lagOrganisasjon(TEST_ORGNR, List.of(AltinnRessurser.ALTINN_TO_TJENESTE), List.of(AltinnRessurser.ALTINN_TRE_RESSURS), List.of());
+        var juridiskEnhet = lagOrganisasjon(JURIDISK_ENHET_ORGNR, List.of(), List.of(), List.of(underenhet));
+        when(altinnKlient.hentTilganger()).thenReturn(lagHierarkiResponse(List.of(juridiskEnhet)));
         var bedrifter = tjeneste.hentBedrifterArbeidsgiverHarTilgangTil();
         assertThat(bedrifter).containsExactly(TEST_ORGNR);
     }
 
     @Test
     void hentBedrifter__altinn2_har_ekstra_orgnr_som_legges_til() {
-        when(altinnKlient.hentTilganger()).thenReturn(
-            new ArbeidsgiverAltinnTilgangerKlient.ArbeidsgiverAltinnTilgangerResponse(
-                false, List.of(), null,
-                Map.of(
-                    AltinnRessurser.ALTINN_TO_TJENESTE, List.of(TEST_ORGNR, ANNET_ORGNR),
-                    AltinnRessurser.ALTINN_TRE_RESSURS, List.of(TEST_ORGNR)
-                )
-            )
-        );
+        var underenhet1 = lagOrganisasjon(TEST_ORGNR, List.of(AltinnRessurser.ALTINN_TO_TJENESTE), List.of(AltinnRessurser.ALTINN_TRE_RESSURS), List.of());
+        var underenhet2 = lagOrganisasjon(ANNET_ORGNR, List.of(AltinnRessurser.ALTINN_TO_TJENESTE), List.of(), List.of());
+        var juridiskEnhet = lagOrganisasjon(JURIDISK_ENHET_ORGNR, List.of(), List.of(), List.of(underenhet1, underenhet2));
+        when(altinnKlient.hentTilganger()).thenReturn(lagHierarkiResponse(List.of(juridiskEnhet)));
         var bedrifter = tjeneste.hentBedrifterArbeidsgiverHarTilgangTil();
         assertThat(bedrifter).containsExactlyInAnyOrder(TEST_ORGNR, ANNET_ORGNR);
+    }
+
+    @Test
+    void hentBedrifter__underenhet_uten_juridisk_enhet_inkluderes() {
+        var underenhet = lagOrganisasjon(TEST_ORGNR, List.of(AltinnRessurser.ALTINN_TO_TJENESTE), List.of(AltinnRessurser.ALTINN_TRE_RESSURS), List.of());
+        when(altinnKlient.hentTilganger()).thenReturn(lagHierarkiResponse(List.of(underenhet)));
+        assertThat(tjeneste.hentBedrifterArbeidsgiverHarTilgangTil()).containsExactly(TEST_ORGNR);
+    }
+
+    @Test
+    void hentBedrifter__juridisk_enhet_med_tilgang_ekskluderes_naar_den_har_underenheter() {
+        var underenhet = lagOrganisasjon(TEST_ORGNR, List.of(AltinnRessurser.ALTINN_TO_TJENESTE), List.of(AltinnRessurser.ALTINN_TRE_RESSURS), List.of());
+        var juridiskEnhet = lagOrganisasjon(JURIDISK_ENHET_ORGNR, List.of(AltinnRessurser.ALTINN_TO_TJENESTE), List.of(AltinnRessurser.ALTINN_TRE_RESSURS), List.of(underenhet));
+        when(altinnKlient.hentTilganger()).thenReturn(lagHierarkiResponse(List.of(juridiskEnhet)));
+        var bedrifter = tjeneste.hentBedrifterArbeidsgiverHarTilgangTil();
+        assertThat(bedrifter).containsExactly(TEST_ORGNR);
+        assertThat(bedrifter).doesNotContain(JURIDISK_ENHET_ORGNR);
     }
 
     // --- Hjelpemetoder ---
@@ -122,8 +135,16 @@ class AltinnTilgangTjenesteTest {
         return new ArbeidsgiverAltinnTilgangerKlient.ArbeidsgiverAltinnTilgangerResponse(false, List.of(), Map.of(orgnr, List.of(tilganger)), null);
     }
 
-    private ArbeidsgiverAltinnTilgangerKlient.ArbeidsgiverAltinnTilgangerResponse lagTilgangTilOrgNrResponse(String tilgang, String... orgnre) {
-        return new ArbeidsgiverAltinnTilgangerKlient.ArbeidsgiverAltinnTilgangerResponse(false, List.of(), null, Map.of(tilgang, List.of(orgnre)));
+    private ArbeidsgiverAltinnTilgangerKlient.ArbeidsgiverAltinnTilgangerResponse lagHierarkiResponse(
+        List<ArbeidsgiverAltinnTilgangerKlient.ArbeidsgiverAltinnTilgangerResponse.Organisasjon> hierarki) {
+        return new ArbeidsgiverAltinnTilgangerKlient.ArbeidsgiverAltinnTilgangerResponse(false, hierarki, null, null);
+    }
+
+    private ArbeidsgiverAltinnTilgangerKlient.ArbeidsgiverAltinnTilgangerResponse.Organisasjon lagOrganisasjon(
+        String orgnr, List<String> altinn2Tilganger, List<String> altinn3Tilganger,
+        List<ArbeidsgiverAltinnTilgangerKlient.ArbeidsgiverAltinnTilgangerResponse.Organisasjon> underenheter) {
+        return new ArbeidsgiverAltinnTilgangerKlient.ArbeidsgiverAltinnTilgangerResponse.Organisasjon(
+            orgnr, altinn3Tilganger, altinn2Tilganger, underenheter, "Testorg", "AS", false);
     }
 }
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
Ved oppslag mot Altinn for å finne organisasjoner som arbeidsgiver har tilgang til, henter vi både juridisk orgNr og underenhet sitt orgNr. Arbeidsforhold er registrert på underenhet, så vi ønsker kun å hente underenhet. 

Jira: https://jira.adeo.no/browse/TSFF-2609

### **Løsning**
Henter ut underenheter ved å traversere `hierarki` i responsen. De organisasjonene som ikke har noen andre organisasjoner under seg er underenheter. 

Jeg tror det kan løses på denne måten, men det må testes i dev.
