### PR TITLE
TSFF-2604: Tjeneste for å purre på alle åpne forespørsler på saken

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/rest/ForespørselRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/rest/ForespørselRest.java
@@ -225,6 +225,18 @@ public class ForespørselRest {
         return Response.ok(new SendNyBeskjedResponse(resultat)).build();
     }
 
+    @POST
+    @Path("/ny-beskjed/sak")
+    @Tilgangskontrollert
+    public Response sendNyBeskjedOgVarselForSak(@Valid @NotNull SaksnummerDto request) {
+        LOG.info("Ny beskjed på aktive forespørsler for saksnummer {}", request.saksnr());
+
+        tilgang.sjekkAtSaksbehandlerHarTilgangTilSak(request.saksnr(), BeskyttetRessursActionAttributt.CREATE);
+
+        forespørselBehandlingTjeneste.opprettNyeBeskjederMedEksternVarsling(request);
+        return Response.ok().build();
+    }
+
     private List<ForespørselEntitet> filtrerDuplikateForespørsler(List<ForespørselEntitet> forespørsler) {
         List<ForespørselEntitet> resultat = new ArrayList<>();
         for (ForespørselEntitet forespørsel : forespørsler) {

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/rest/ForespørselRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/rest/ForespørselRest.java
@@ -57,6 +57,8 @@ public class ForespørselRest {
     public static final String LUKK_PATH = "/lukk";
     public static final String SETT_TIL_UTGÅTT_PATH = "/sett-til-utgatt";
     public static final String HENT_FORESPØRSLER_FOR_SAK_PATH = "/sak";
+    public static final String NY_BESKJED_PATH = "/ny-beskjed";
+    public static final String NY_BESKJED_SAK_PATH = "/ny-beskjed/sak";
 
     private ForespørselBehandlingTjeneste forespørselBehandlingTjeneste;
     private Tilgang tilgang;
@@ -214,7 +216,7 @@ public class ForespørselRest {
     }
 
     @POST
-    @Path("/ny-beskjed")
+    @Path(NY_BESKJED_PATH)
     @Tilgangskontrollert
     public Response sendNyBeskjedOgVarsel(@Valid @NotNull NyBeskjedRequest request) {
         LOG.info("Ny beskjed på aktiv forespørsel for saksnummer {} med orgnummer {}", request.saksnummer(), request.orgnr());
@@ -226,7 +228,7 @@ public class ForespørselRest {
     }
 
     @POST
-    @Path("/ny-beskjed/sak")
+    @Path(NY_BESKJED_SAK_PATH)
     @Tilgangskontrollert
     public Response sendNyBeskjedOgVarselForSak(@Valid @NotNull SaksnummerDto request) {
         LOG.info("Ny beskjed på aktive forespørsler for saksnummer {}", request.saksnr());

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -479,6 +479,13 @@ public class ForespørselBehandlingTjeneste {
             .max(Comparator.comparing(f -> f.getFørsteUttaksdato().orElse(f.getSkjæringstidspunkt())));
     }
 
+    public void opprettNyeBeskjederMedEksternVarsling(SaksnummerDto saksnummer) {
+        var åpneForespørsler = forespørselTjeneste.finnÅpneForespørslerForFagsak(saksnummer);
+        for (var forespørsel : åpneForespørsler) {
+            opprettNyBeskjedMedEksternVarsling(forespørsel);
+        }
+    }
+
     public NyBeskjedResultat opprettNyBeskjedMedEksternVarsling(SaksnummerDto saksnummer, OrganisasjonsnummerDto organisasjonsnummer, LocalDate skjæringstidspunkt) {
         final ForespørselEntitet forespørsel = hentForespørslerForFagsak(saksnummer, organisasjonsnummer, skjæringstidspunkt).stream()
             .filter(f -> f.getStatus() == ForespørselStatus.UNDER_BEHANDLING)
@@ -488,6 +495,11 @@ public class ForespørselBehandlingTjeneste {
             return NyBeskjedResultat.FORESPØRSEL_FINNES_IKKE;
         }
 
+        opprettNyBeskjedMedEksternVarsling(forespørsel);
+        return NyBeskjedResultat.NY_BESKJED_SENDT;
+    }
+
+    private void opprettNyBeskjedMedEksternVarsling(ForespørselEntitet forespørsel) {
         Merkelapp merkelapp = ForespørselTekster.finnMerkelapp(forespørsel.getYtelseType());
         UUID forespørselUuid = forespørsel.getUuid();
         URI skjemaUri = URI.create(inntektsmeldingSkjemaLenke + "/" + forespørselUuid);
@@ -502,8 +514,6 @@ public class ForespørselBehandlingTjeneste {
             beskjedTekst,
             varselTekst,
             skjemaUri);
-
-        return NyBeskjedResultat.NY_BESKJED_SENDT;
     }
 
     private void validerOrganisasjon(ForespørselEntitet forespørsel, OrganisasjonsnummerDto orgnummer) {

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -20,6 +20,7 @@ import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
 import no.nav.familie.inntektsmelding.forespørsel.tjenester.task.GjenåpneForespørselTask;
 import no.nav.familie.inntektsmelding.forespørsel.tjenester.task.OppdaterForespørselTask;
 import no.nav.familie.inntektsmelding.forespørsel.tjenester.task.OpprettForespørselTask;
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.task.SendNyBeskjedOgVarselTask;
 import no.nav.familie.inntektsmelding.forespørsel.tjenester.task.SettForespørselTilUtgåttTask;
 import no.nav.familie.inntektsmelding.forvaltning.rest.InntektsmeldingForespørselDto;
 import no.nav.familie.inntektsmelding.imdialog.modell.DelvisFraværsPeriodeEntitet;
@@ -43,6 +44,7 @@ import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
 import no.nav.familie.inntektsmelding.typer.dto.SaksnummerDto;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
 import no.nav.foreldrepenger.konfig.Environment;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskGruppe;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
@@ -480,10 +482,17 @@ public class ForespørselBehandlingTjeneste {
     }
 
     public void opprettNyeBeskjederMedEksternVarsling(SaksnummerDto saksnummer) {
-        var åpneForespørsler = forespørselTjeneste.finnÅpneForespørslerForFagsak(saksnummer);
+        List<ForespørselEntitet> åpneForespørsler = forespørselTjeneste.finnÅpneForespørslerForFagsak(saksnummer);
+        List<ProsessTaskData> tasker = new ArrayList<>();
         for (var forespørsel : åpneForespørsler) {
-            opprettNyBeskjedMedEksternVarsling(forespørsel);
+            var task = ProsessTaskData.forProsessTask(SendNyBeskjedOgVarselTask.class);
+            task.setProperty(SendNyBeskjedOgVarselTask.FORESPØRSEL_UUID, forespørsel.getUuid().toString());
+            tasker.add(task);
         }
+        var taskGruppe = new ProsessTaskGruppe();
+        taskGruppe.addNesteParallell(tasker);
+        taskGruppe.setSaksnummer(saksnummer.saksnr());
+        prosessTaskTjeneste.lagre(taskGruppe);
     }
 
     public NyBeskjedResultat opprettNyBeskjedMedEksternVarsling(SaksnummerDto saksnummer, OrganisasjonsnummerDto organisasjonsnummer, LocalDate skjæringstidspunkt) {
@@ -499,7 +508,7 @@ public class ForespørselBehandlingTjeneste {
         return NyBeskjedResultat.NY_BESKJED_SENDT;
     }
 
-    private void opprettNyBeskjedMedEksternVarsling(ForespørselEntitet forespørsel) {
+    public void opprettNyBeskjedMedEksternVarsling(ForespørselEntitet forespørsel) {
         Merkelapp merkelapp = ForespørselTekster.finnMerkelapp(forespørsel.getYtelseType());
         UUID forespørselUuid = forespørsel.getUuid();
         URI skjemaUri = URI.create(inntektsmeldingSkjemaLenke + "/" + forespørselUuid);

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -129,13 +129,13 @@ public class ForespørselBehandlingTjeneste {
                                      List<OppdaterForespørselDto> forespørsler,
                                      SaksnummerDto saksnummer) {
         final var eksisterendeForespørsler = forespørselTjeneste.finnForespørslerForFagsak(saksnummer);
-        final var taskGruppe = new ProsessTaskGruppe();
+        final List<ProsessTaskData> tasker = new ArrayList<>();
 
         // Forespørsler som skal opprettes
         var skalOpprettes = utledNyeForespørsler(forespørsler, eksisterendeForespørsler);
         for (OppdaterForespørselDto forespørselDto : skalOpprettes) {
             var opprettForespørselTask = OpprettForespørselTask.lagOpprettForespørselTaskData(ytelsetype, aktørId, saksnummer, forespørselDto);
-            taskGruppe.addNesteParallell(opprettForespørselTask);
+            tasker.add(opprettForespørselTask);
         }
 
         // Forespørsler som skal oppdateres
@@ -143,7 +143,7 @@ public class ForespørselBehandlingTjeneste {
             var skalOppdateres = utledForespørslerSomSkalOppdateres(forespørsler, eksisterendeForespørsler);
             for (ForespørselOppdatering forespørsel : skalOppdateres) {
                 var oppdaterForespørselTask = OppdaterForespørselTask.lagOppdaterTaskData(forespørsel.forespørselUuid(), ytelsetype, forespørsel.oppdaterDto().etterspurtePerioder());
-                taskGruppe.addNesteParallell(oppdaterForespørselTask);
+                tasker.add(oppdaterForespørselTask);
             }
         }
 
@@ -151,17 +151,20 @@ public class ForespørselBehandlingTjeneste {
         var skalSettesUtgått = utledForespørslerSomSkalSettesUtgått(forespørsler, eksisterendeForespørsler);
         for (ForespørselEntitet forespørsel : skalSettesUtgått) {
             var settForespørselTilUtgåttTask = SettForespørselTilUtgåttTask.lagSettTilUtgåttTask(forespørsel.getUuid(), saksnummer);
-            taskGruppe.addNesteParallell(settForespørselTilUtgåttTask);
+            tasker.add(settForespørselTilUtgåttTask);
         }
 
         // Forespørsler som skal gjenåpnes
         var skalGjenåpnes = utledForespørslerSomSkalGjenåpnes(forespørsler, eksisterendeForespørsler);
         for (ForespørselEntitet forespørsel : skalGjenåpnes) {
             var gjenåpneForespørselTask = GjenåpneForespørselTask.lagGjenåpneForespørselTask(forespørsel.getUuid(), saksnummer);
-            taskGruppe.addNesteParallell(gjenåpneForespørselTask);
+            tasker.add(gjenåpneForespørselTask);
         }
 
-        if (!taskGruppe.getTasks().isEmpty()) {
+        if (!tasker.isEmpty()) {
+            var taskGruppe = new ProsessTaskGruppe();
+            taskGruppe.addNesteParallell(tasker);
+            taskGruppe.setSaksnummer(saksnummer.saksnr());
             prosessTaskTjeneste.lagre(taskGruppe);
         } else {
             LOG.info("Ingen oppdatering er nødvendig for saksnummer: {}", saksnummer);

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/SendNyBeskjedOgVarselTask.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/SendNyBeskjedOgVarselTask.java
@@ -1,0 +1,49 @@
+package no.nav.familie.inntektsmelding.forespørsel.tjenester.task;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import jakarta.inject.Inject;
+
+import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
+import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselRepository;
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
+import no.nav.familie.inntektsmelding.koder.ForespørselStatus;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
+
+@ApplicationScoped
+@ProsessTask("forespørsel.nyBeskjedOgVarsel")
+public class SendNyBeskjedOgVarselTask implements ProsessTaskHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SendNyBeskjedOgVarselTask.class);
+    public static final String FORESPØRSEL_UUID = "forespoerselUUID";
+
+    private final ForespørselRepository forespørselRepository;
+    private final ForespørselBehandlingTjeneste forespørselBehandlingTjeneste;
+
+    @Inject
+    public SendNyBeskjedOgVarselTask(ForespørselRepository forespørselRepository,
+                                     ForespørselBehandlingTjeneste forespørselBehandlingTjeneste) {
+        this.forespørselRepository = forespørselRepository;
+        this.forespørselBehandlingTjeneste = forespørselBehandlingTjeneste;
+    }
+
+    @Override
+    public void doTask(ProsessTaskData prosessTaskData) {
+        UUID uuid = UUID.fromString(prosessTaskData.getPropertyValue(FORESPØRSEL_UUID));
+        Optional<ForespørselEntitet> forespørsel = forespørselRepository.hentForespørsel(uuid);
+        if (forespørsel.isPresent() && forespørsel.get().getStatus() == ForespørselStatus.UNDER_BEHANDLING) {
+            LOG.info("Sender ny beskjed for forespørsel: {}", forespørsel);
+            forespørselBehandlingTjeneste.opprettNyBeskjedMedEksternVarsling(forespørsel.get());
+        } else {
+            LOG.info("Forespørsel med uuid {} er ferdig/utgått eller finnes ikke.", uuid);
+        }
+    }
+}


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi skal purre automatisk fra steget i k9-sak, og ikke manuelt per forespørsel
### **Løsning**
Lager ny resttjeneste som purrer på alle åpne forespørsler på saken. Det gjør det mye enklere for k9-sak.
Bruker en prosesstask per forespørsel for bedre feilhåndtering.
### **Andre endringer**
Retter bruken av addNesteParalell. Den oppfører seg som addNesteSekvensiell dersom man bruker den på taskene enkeltvis. Må derfor samle dem opp i en collection først og så sende inn til metoden.