### PR TITLE
Chore: fjern k9-dokgen fra outbound rules

### DIFF
--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -107,8 +107,6 @@ spec:
           namespace: fager
         - application: arbeidsgiver-altinn-tilganger
           namespace: fager
-        - application: k9-dokgen
-          namespace: k9saksbehandling
         - application: k9-pdfgen-psb
           namespace: k9saksbehandling
         - application: sif-abac-pdp


### PR DESCRIPTION
### **Behov / Bakgrunn**
K9-dokgen er erstattet med k9-pdfgen-psb

### **Løsning**
Fjern gammel outbound rule for k9-dokgen
