### PR TITLE
Feature: Nye driftendepunkt for å hente statistikk for antall inntektsmeldinger og hvor lenge de ligger på vent

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselRepository.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselRepository.java
@@ -165,4 +165,34 @@ public class ForespørselRepository {
             throw new IllegalStateException("Forventet å finne en forespørsel for oppgitt uuid " + forespørselUuid);
         }
     }
+
+    public long tellForespørslerMedStatus(LocalDate fraDato, LocalDate tilDato, ForespørselStatus status) {
+        var query = entityManager.createQuery("""
+                SELECT COUNT(f) FROM ForespørselEntitet f
+                WHERE f.opprettetTidspunkt >= :fraDato
+                  AND f.opprettetTidspunkt < :tilDato
+                  AND f.status = :status
+                """, Long.class)
+            .setParameter("fraDato", fraDato.atStartOfDay())
+            .setParameter("tilDato", tilDato.plusDays(1).atStartOfDay())
+            .setParameter("status", status);
+        return query.getSingleResult();
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<Object[]> hentDagerTilLukkingFordeling(LocalDate fraDato, LocalDate tilDato) {
+        var query = entityManager.createNativeQuery("""
+                SELECT CAST(endret_tid AS DATE) - CAST(opprettet_tid AS DATE) AS antall_dager,
+                       COUNT(*) AS antall_forespoersler
+                FROM forespoersel
+                WHERE CAST(opprettet_tid AS DATE) >= :fraDato
+                  AND CAST(opprettet_tid AS DATE) <= :tilDato
+                  AND status = 'FERDIG'
+                GROUP BY 1
+                ORDER BY 1
+                """)
+            .setParameter("fraDato", fraDato)
+            .setParameter("tilDato", tilDato);
+        return query.getResultList();
+    }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/forvaltning/StatistikkForvaltningRestTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forvaltning/StatistikkForvaltningRestTjeneste.java
@@ -1,11 +1,15 @@
 package no.nav.familie.inntektsmelding.forvaltning;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -14,7 +18,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselRepository;
 import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingRepository;
+import no.nav.familie.inntektsmelding.koder.ForespørselStatus;
 import no.nav.familie.inntektsmelding.server.auth.api.AutentisertMedAzure;
 import no.nav.familie.inntektsmelding.server.auth.api.Tilgangskontrollert;
 import no.nav.familie.inntektsmelding.server.tilgangsstyring.Tilgang;
@@ -29,15 +35,19 @@ public class StatistikkForvaltningRestTjeneste {
 
     private Tilgang tilgang;
     private InntektsmeldingRepository inntektsmeldingRepository;
+    private ForespørselRepository forespørselRepository;
 
     StatistikkForvaltningRestTjeneste() {
         // REST CDI
     }
 
     @Inject
-    public StatistikkForvaltningRestTjeneste(Tilgang tilgang, InntektsmeldingRepository inntektsmeldingRepository) {
+    public StatistikkForvaltningRestTjeneste(Tilgang tilgang,
+                                             InntektsmeldingRepository inntektsmeldingRepository,
+                                             ForespørselRepository forespørselRepository) {
         this.tilgang = tilgang;
         this.inntektsmeldingRepository = inntektsmeldingRepository;
+        this.forespørselRepository = forespørselRepository;
     }
 
     @GET
@@ -92,10 +102,72 @@ public class StatistikkForvaltningRestTjeneste {
         return Response.ok(new AntallInntektsmeldingerResponse(antall)).build();
     }
 
+    @GET
+    @Path("/antall-ferdige-forespoersler")
+    @Operation(description = "Teller antall forespørsler med status FERDIG i angitt periode", summary = "Teller antall ferdige forespørsler.", tags = "statistikk", responses = {
+        @ApiResponse(responseCode = "200", description = "Antall ferdige forespørsler hentet", content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "500", description = "Feilet pga ukjent feil eller tekniske/funksjonelle feil")
+    })
+    @Tilgangskontrollert
+    public Response hentAntallFerdigeForespørsler(@QueryParam("fraDato") LocalDate fraDato, @QueryParam("tilDato") LocalDate tilDato) {
+        sjekkAtKallerHarRollenDrift();
+        validerDatoParametere(fraDato, tilDato);
+        long antall = forespørselRepository.tellForespørslerMedStatus(fraDato, tilDato, ForespørselStatus.FERDIG);
+        return Response.ok(new AntallForespørslerResponse(antall)).build();
+    }
+
+    @GET
+    @Path("/antall-under-behandling-forespoersler")
+    @Operation(description = "Teller antall forespørsler med status UNDER_BEHANDLING i angitt periode", summary = "Teller antall forespørsler under behandling.", tags = "statistikk", responses = {
+        @ApiResponse(responseCode = "200", description = "Antall forespørsler under behandling hentet", content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "500", description = "Feilet pga ukjent feil eller tekniske/funksjonelle feil")
+    })
+    @Tilgangskontrollert
+    public Response hentAntallUnderBehandlingForespørsler(@QueryParam("fraDato") LocalDate fraDato, @QueryParam("tilDato") LocalDate tilDato) {
+        sjekkAtKallerHarRollenDrift();
+        validerDatoParametere(fraDato, tilDato);
+        long antall = forespørselRepository.tellForespørslerMedStatus(fraDato, tilDato, ForespørselStatus.UNDER_BEHANDLING);
+        return Response.ok(new AntallForespørslerResponse(antall)).build();
+    }
+
+    @GET
+    @Path("/dager-til-lukking")
+    @Operation(description = "Henter fordeling av antall dager fra opprettet til lukket (endret_tid - opprettet_tid) for ferdige forespørsler i angitt periode", summary = "Henter dager til lukking fordeling.", tags = "statistikk", responses = {
+        @ApiResponse(responseCode = "200", description = "Fordeling hentet", content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "500", description = "Feilet pga ukjent feil eller tekniske/funksjonelle feil")
+    })
+    @Tilgangskontrollert
+    public Response hentDagerTilLukking(@QueryParam("fraDato") LocalDate fraDato, @QueryParam("tilDato") LocalDate tilDato) {
+        sjekkAtKallerHarRollenDrift();
+        validerDatoParametere(fraDato, tilDato);
+        var rader = forespørselRepository.hentDagerTilLukkingFordeling(fraDato, tilDato).stream()
+            .map(row -> new DagerTilLukking(((Number) row[0]).intValue(), ((Number) row[1]).longValue()))
+            .toList();
+        return Response.ok(new DagerTilLukkingResponse(rader)).build();
+    }
+
     protected record AntallInntektsmeldingerResponse(long antall) {
+    }
+
+    protected record AntallForespørslerResponse(long antall) {
+    }
+
+    protected record DagerTilLukking(int antallDager, long antallForespørsler) {
+    }
+
+    protected record DagerTilLukkingResponse(List<DagerTilLukking> dagerTilLukking) {
     }
 
     private void sjekkAtKallerHarRollenDrift() {
         tilgang.sjekkAtAnsattHarRollenDrift();
+    }
+
+    private void validerDatoParametere(LocalDate fraDato, LocalDate tilDato) {
+        if (fraDato == null || tilDato == null) {
+            throw new IllegalArgumentException("fraDato og tilDato må være satt");
+        }
+        if (fraDato.isAfter(tilDato)) {
+            throw new IllegalArgumentException("fraDato kan ikke være etter tilDato");
+        }
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/forvaltning/StatistikkForvaltningRestTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forvaltning/StatistikkForvaltningRestTjeneste.java
@@ -6,6 +6,7 @@ import java.util.List;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -109,7 +110,8 @@ public class StatistikkForvaltningRestTjeneste {
         @ApiResponse(responseCode = "500", description = "Feilet pga ukjent feil eller tekniske/funksjonelle feil")
     })
     @Tilgangskontrollert
-    public Response hentAntallFerdigeForespørsler(@QueryParam("fraDato") LocalDate fraDato, @QueryParam("tilDato") LocalDate tilDato) {
+    public Response hentAntallFerdigeForespørsler(@Valid @QueryParam("fraDato") LocalDate fraDato,
+                                                  @Valid @QueryParam("tilDato") LocalDate tilDato) {
         sjekkAtKallerHarRollenDrift();
         validerDatoParametere(fraDato, tilDato);
         long antall = forespørselRepository.tellForespørslerMedStatus(fraDato, tilDato, ForespørselStatus.FERDIG);
@@ -123,7 +125,8 @@ public class StatistikkForvaltningRestTjeneste {
         @ApiResponse(responseCode = "500", description = "Feilet pga ukjent feil eller tekniske/funksjonelle feil")
     })
     @Tilgangskontrollert
-    public Response hentAntallUnderBehandlingForespørsler(@QueryParam("fraDato") LocalDate fraDato, @QueryParam("tilDato") LocalDate tilDato) {
+    public Response hentAntallUnderBehandlingForespørsler(@Valid @QueryParam("fraDato") LocalDate fraDato,
+                                                          @Valid @QueryParam("tilDato") LocalDate tilDato) {
         sjekkAtKallerHarRollenDrift();
         validerDatoParametere(fraDato, tilDato);
         long antall = forespørselRepository.tellForespørslerMedStatus(fraDato, tilDato, ForespørselStatus.UNDER_BEHANDLING);
@@ -137,7 +140,8 @@ public class StatistikkForvaltningRestTjeneste {
         @ApiResponse(responseCode = "500", description = "Feilet pga ukjent feil eller tekniske/funksjonelle feil")
     })
     @Tilgangskontrollert
-    public Response hentDagerTilLukking(@QueryParam("fraDato") LocalDate fraDato, @QueryParam("tilDato") LocalDate tilDato) {
+    public Response hentDagerTilLukking(@Valid @QueryParam("fraDato") LocalDate fraDato,
+                                        @Valid @QueryParam("tilDato") LocalDate tilDato) {
         sjekkAtKallerHarRollenDrift();
         validerDatoParametere(fraDato, tilDato);
         var rader = forespørselRepository.hentDagerTilLukkingFordeling(fraDato, tilDato).stream()

--- a/src/main/java/no/nav/familie/inntektsmelding/forvaltning/StatistikkForvaltningRestTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forvaltning/StatistikkForvaltningRestTjeneste.java
@@ -6,6 +6,8 @@ import java.util.List;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -109,8 +111,8 @@ public class StatistikkForvaltningRestTjeneste {
         @ApiResponse(responseCode = "500", description = "Feilet pga ukjent feil eller tekniske/funksjonelle feil")
     })
     @Tilgangskontrollert
-    public Response hentAntallFerdigeForespørsler(@QueryParam("fraDato") String fraDatoStr,
-                                                  @QueryParam("tilDato") String tilDatoStr) {
+    public Response hentAntallFerdigeForespørsler(@Valid @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}") @QueryParam("fraDato") String fraDatoStr,
+                                                  @Valid @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}") @QueryParam("tilDato") String tilDatoStr) {
         sjekkAtKallerHarRollenDrift();
         var fraDato = parseDato(fraDatoStr, "fraDato");
         var tilDato = parseDato(tilDatoStr, "tilDato");
@@ -126,8 +128,8 @@ public class StatistikkForvaltningRestTjeneste {
         @ApiResponse(responseCode = "500", description = "Feilet pga ukjent feil eller tekniske/funksjonelle feil")
     })
     @Tilgangskontrollert
-    public Response hentAntallUnderBehandlingForespørsler(@QueryParam("fraDato") String fraDatoStr,
-                                                          @QueryParam("tilDato") String tilDatoStr) {
+    public Response hentAntallUnderBehandlingForespørsler(@Valid @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}") @QueryParam("fraDato") String fraDatoStr,
+                                                          @Valid @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}") @QueryParam("tilDato") String tilDatoStr) {
         sjekkAtKallerHarRollenDrift();
         var fraDato = parseDato(fraDatoStr, "fraDato");
         var tilDato = parseDato(tilDatoStr, "tilDato");
@@ -143,8 +145,8 @@ public class StatistikkForvaltningRestTjeneste {
         @ApiResponse(responseCode = "500", description = "Feilet pga ukjent feil eller tekniske/funksjonelle feil")
     })
     @Tilgangskontrollert
-    public Response hentDagerTilLukking(@QueryParam("fraDato") String fraDatoStr,
-                                        @QueryParam("tilDato") String tilDatoStr) {
+    public Response hentDagerTilLukking(@Valid @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}") @QueryParam("fraDato") String fraDatoStr,
+                                        @Valid @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}") @QueryParam("tilDato") String tilDatoStr) {
         sjekkAtKallerHarRollenDrift();
         var fraDato = parseDato(fraDatoStr, "fraDato");
         var tilDato = parseDato(tilDatoStr, "tilDato");

--- a/src/main/java/no/nav/familie/inntektsmelding/forvaltning/StatistikkForvaltningRestTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forvaltning/StatistikkForvaltningRestTjeneste.java
@@ -6,7 +6,6 @@ import java.util.List;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import jakarta.validation.Valid;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -110,9 +109,11 @@ public class StatistikkForvaltningRestTjeneste {
         @ApiResponse(responseCode = "500", description = "Feilet pga ukjent feil eller tekniske/funksjonelle feil")
     })
     @Tilgangskontrollert
-    public Response hentAntallFerdigeForespørsler(@Valid @QueryParam("fraDato") LocalDate fraDato,
-                                                  @Valid @QueryParam("tilDato") LocalDate tilDato) {
+    public Response hentAntallFerdigeForespørsler(@QueryParam("fraDato") String fraDatoStr,
+                                                  @QueryParam("tilDato") String tilDatoStr) {
         sjekkAtKallerHarRollenDrift();
+        var fraDato = parseDato(fraDatoStr, "fraDato");
+        var tilDato = parseDato(tilDatoStr, "tilDato");
         validerDatoParametere(fraDato, tilDato);
         long antall = forespørselRepository.tellForespørslerMedStatus(fraDato, tilDato, ForespørselStatus.FERDIG);
         return Response.ok(new AntallForespørslerResponse(antall)).build();
@@ -125,9 +126,11 @@ public class StatistikkForvaltningRestTjeneste {
         @ApiResponse(responseCode = "500", description = "Feilet pga ukjent feil eller tekniske/funksjonelle feil")
     })
     @Tilgangskontrollert
-    public Response hentAntallUnderBehandlingForespørsler(@Valid @QueryParam("fraDato") LocalDate fraDato,
-                                                          @Valid @QueryParam("tilDato") LocalDate tilDato) {
+    public Response hentAntallUnderBehandlingForespørsler(@QueryParam("fraDato") String fraDatoStr,
+                                                          @QueryParam("tilDato") String tilDatoStr) {
         sjekkAtKallerHarRollenDrift();
+        var fraDato = parseDato(fraDatoStr, "fraDato");
+        var tilDato = parseDato(tilDatoStr, "tilDato");
         validerDatoParametere(fraDato, tilDato);
         long antall = forespørselRepository.tellForespørslerMedStatus(fraDato, tilDato, ForespørselStatus.UNDER_BEHANDLING);
         return Response.ok(new AntallForespørslerResponse(antall)).build();
@@ -140,9 +143,11 @@ public class StatistikkForvaltningRestTjeneste {
         @ApiResponse(responseCode = "500", description = "Feilet pga ukjent feil eller tekniske/funksjonelle feil")
     })
     @Tilgangskontrollert
-    public Response hentDagerTilLukking(@Valid @QueryParam("fraDato") LocalDate fraDato,
-                                        @Valid @QueryParam("tilDato") LocalDate tilDato) {
+    public Response hentDagerTilLukking(@QueryParam("fraDato") String fraDatoStr,
+                                        @QueryParam("tilDato") String tilDatoStr) {
         sjekkAtKallerHarRollenDrift();
+        var fraDato = parseDato(fraDatoStr, "fraDato");
+        var tilDato = parseDato(tilDatoStr, "tilDato");
         validerDatoParametere(fraDato, tilDato);
         var rader = forespørselRepository.hentDagerTilLukkingFordeling(fraDato, tilDato).stream()
             .map(row -> new DagerTilLukking(((Number) row[0]).intValue(), ((Number) row[1]).longValue()))
@@ -164,6 +169,17 @@ public class StatistikkForvaltningRestTjeneste {
 
     private void sjekkAtKallerHarRollenDrift() {
         tilgang.sjekkAtAnsattHarRollenDrift();
+    }
+
+    private static LocalDate parseDato(String verdi, String paramNavn) {
+        if (verdi == null || verdi.isBlank()) {
+            return null;
+        }
+        try {
+            return LocalDate.parse(verdi);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Ugyldig datoformat for " + paramNavn + ": '" + verdi + "'. Forventet ISO-8601 (yyyy-MM-dd).");
+        }
     }
 
     private void validerDatoParametere(LocalDate fraDato, LocalDate tilDato) {


### PR DESCRIPTION
### Behov / Bakgrunn
Vi har behov for å vite hvor mange forespørsler vi har opprettet, hvor mange vi har fått inn og hvor lenge de ligger på vent. 

### Løsning
Legger til driftsendepunkt for henting av statistikk. 

Dette burde legges inn som statistikk for bigquery etter hvert.


---

### Sjekkliste for godkjenner

- [x] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [x] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [x] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
