### PR TITLE
chore: GitHub governance-oppsett

### DIFF
--- a/.github/instructions/governance-review-okonomi.instructions.md
+++ b/.github/instructions/governance-review-okonomi.instructions.md
@@ -5,27 +5,16 @@ excludeAgent: "cloud-agent"
 
 # Økonomireglementet — spesielle hensyn
 
-Denne kodebasen forvalter ytelser og utbetalinger underlagt økonomireglementet (Reglement for økonomistyring i staten).
-Copilot skal spesielt vurdere følgende:
+Kodebasen forvalter ytelser/utbetalinger underlagt økonomireglementet. Flagg for menneskelig reviewer.
 
 ## Uhensiktsmessig spesialbehandling
-- Flagg kode som innfører logikk for å behandle enkeltpersoner, enkeltorganisasjoner eller spesifikke saker ulikt uten saklig grunnlag
-- Eksempler: hardkodede aktørId-er, fødselsnumre, saksnumre eller organisasjonsnumre som styrer forretningslogikk
-- Unntak: testdata, feiltoleransefiltre med tydelig midlertidig kommentar og tilhørende oppfølgingssak
+Logikk som behandler enkeltpersoner/organisasjoner/saker ulikt uten saklig grunnlag: hardkodede aktørId, FNR, saksnummer, orgnummer i forretningslogikk. Unntak: testdata, midlertidige filtre med kommentar + oppfølgingssak.
 
 ## Flyway-migrasjoner (økonomisk data)
-- Migrasjonsfiler som endrer tabeller med finansielle data (ytelse, beregning, oppdrag, tilbakekreving, vedtak, utbetaling, refusjon)
-- Destruktive migrasjoner (DROP TABLE, DROP COLUMN, ALTER COLUMN type change) på produksjonstabeller
-- Manglende eller feil versjonsnummerering i migrasjonsfiler
-- Migrasjoner som endrer beregningsgrunnlag, satser eller vedtaksdata krever ekstra oppmerksomhet
+Tabeller med finansielle data (ytelse, beregning, oppdrag, tilbakekreving, vedtak, utbetaling, refusjon). Destruktive migrasjoner (DROP TABLE/COLUMN, ALTER type). Feil versjonsnummerering. Endring av beregningsgrunnlag/satser/vedtaksdata.
 
-## Sporbarhet og begrunnelse
-- Sjekk at PR-beskrivelsen inneholder minst én av:
-  - Lenke til Jira-sak, GitHub issue eller Slack-tråd
-  - En tydelig beskrivelse av **hvorfor** endringen gjøres
-- Endringer i forretningslogikk uten sporbar begrunnelse skal flagges
+## Sporbarhet
+PR-beskrivelse skal inneholde lenke (Jira, issue, Slack) eller tydelig **hvorfor**. Forretningslogikk uten sporbar begrunnelse → flagg.
 
-## Rimelighet og proporsjonalitet
-- Vurder om endringene er rimelige i omfang relativt til beskrevet behov
-- Flagg hvis endringen har utilsiktede sideeffekter på beregning eller utbetaling
-- Varsle hvis feilhåndtering endres på måter som kan føre til feilutbetalinger eller tapte krav
+## Rimelighet
+Rimelig omfang vs. beskrevet behov. Utilsiktede sideeffekter på beregning/utbetaling. Feilhåndteringsendringer som kan føre til feilutbetalinger/tapte krav.

--- a/.github/instructions/governance-review.instructions.md
+++ b/.github/instructions/governance-review.instructions.md
@@ -5,56 +5,35 @@ excludeAgent: "cloud-agent"
 
 # Generelle review-instruksjoner
 
-Disse instruksjonene gjelder for GitHub Copilot code review for alle filer i dette repoet.
+Gjelder GitHub Copilot code review for alle filer i dette repoet. Flagg for menneskelig reviewer — ikke blokker.
 
 ## Generelle sjekker
 
-### Branch-navngivning
-Flagg dersom source branch ikke følger navnekonvensjon. Forventede prefikser:
-- `feature/`, `fix/`, `chore/`, `docs/`
+- **Branch-navn**: forventet prefiks `feature/`, `fix/`, `chore/`, `docs/`
+- **Relevans**: rimelig omfang, ingen urelaterte endringer
 
-### Relevans
-Verifiser at endringene er rimelige i omfang og relevante for oppgitt formål.
-Flagg dersom PRen inneholder urelaterte endringer blandet inn.
+## Domene-spesifikke flaggingspunkter
 
-## Domene-spesifikke punkter
+### NAIS-konfig
+Endringer i `nais*.yaml`/`naiserator.yaml`: `accessPolicy`, `env` (secrets, SCOPE, credentials), `azure.application`/`tokenx`, ressursgrenser, replicas
 
-Flagg følgende for menneskelig reviewer. Ikke blokker — fremhev med kommentar.
+### Autentisering/autorisasjon
+Tokens, OIDC, SAML, `@BeskyttetRessurs`, `@ProtectedWithClaims`, ABAC-evaluering, tilgangssjekker, endrede API-endepunkter
 
-### NAIS-konfigurasjon
-- Endringer i `nais*.yaml` eller `naiserator.yaml` som modifiserer:
-  - `accessPolicy` (inbound/outbound-regler)
-  - `env`-variabler (spesielt secrets, SCOPE, credentials)
-  - `azure.application` eller `tokenx`-konfigurasjon
-  - Ressursgrenser eller replicas
-
-### Autentisering og autorisasjon
-- Endringer i kode som håndterer tokens, OIDC, SAML, `@BeskyttetRessurs` eller `@ProtectedWithClaims`
-- Endringer i ABAC policy-evaluering eller tilgangssjekker
-- Nye eller endrede API-endepunkter som endrer tilgangskontroll
-
-### ProsessTask og jobbstyring
-- Nye `ProsessTask`-implementasjoner eller endringer i task type-definisjoner
-- Endringer i cron-uttrykk eller konfigurering av planlagte jobber
-- Endringer i retry-logikk eller feilhåndtering i asynkrone tasks
+### ProsessTask/jobbstyring
+Nye/endrede `ProsessTask`, cron-uttrykk, retry-logikk, feilhåndtering i async tasks
 
 ### Integrasjonspunkter
-- Endringer i klienter som kaller eksterne systemer (spesielt Økonomi/OS, Infotrygd, PDL, Dokarkiv)
-- Endringer i Kafka-produsenter/konsumenter (topic-navn, serialisering, feilhåndtering)
-- Nye eller endrede REST/SOAP-klientkonfigurasjoner
+Klienter mot eksterne systemer (Økonomi/OS, Infotrygd, PDL, Dokarkiv), Kafka (topic, serialisering, feilhåndtering), REST/SOAP-klienter
 
-### Miljøvariabler og hemmeligheter
-- Nye eller endrede miljøvariabler som inneholder `SCOPE`, `CLIENT_ID`, `CLIENT_SECRET` eller `CREDENTIAL`
-- Referanser til Vault eller Azure Key Vault-hemmeligheter
-- Hardkodede URLer, tokens eller credentials (flagg som sikkerhetsproblem)
+### Miljøvariabler/hemmeligheter
+Variabler med `SCOPE`, `CLIENT_ID`, `CLIENT_SECRET`, `CREDENTIAL`; Vault/Azure Key Vault-refs; hardkodede URLer/tokens/credentials (→ sikkerhetsflagg)
 
-### GitHub Actions workflows
-- Endringer i `.github/workflows/` som påvirker bygg, test eller deploy-pipelines
-- Fjerning eller svekkelse av teststeg
-- Endringer i deployment-targets eller betingelser
-- Upinnede action-versjoner (bør bruke SHA eller versjonstagg)
+### Sensitive data i output
+FNR, aktørId, tokens eller request-verdier eksponert via logg, exception-meldinger eller valideringsannotasjoner (`${validatedValue}` i `@Pattern`/`@Size` o.l.) → sikkerhetsflagg
 
-### Test- og deployment-sikringer
-- Fjerning av test-assertions eller testfiler uten erstatning
-- Endringer som hopper over eller deaktiverer tester (`@Disabled`, `skipTests`)
-- Modifikasjoner av deployment-guards eller approval-gates
+### GitHub Actions
+Endringer i `.github/workflows/`: bygg/test/deploy, fjerning/svekkelse av teststeg, deployment-targets, upinnede action-versjoner
+
+### Test/deployment-sikringer
+Fjerning av test-assertions/testfiler, `@Disabled`/`skipTests`, endrede deployment-guards/approval-gates


### PR DESCRIPTION
Standardiserer governance-filer på tvers av teamets repoer for å sikre konsistent CODEOWNERS, review-instruksjoner, PR-mal og eventuelle labels.

Filene vedlikeholdes sentralt i [sif-team/governance](https://github.com/navikt/sif-team/tree/main/governance) og distribueres med `distribute_files.sh`.