### PR TITLE
Bruke altinn 3 ressurs

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/MinSideArbeidsgiverTjenesteImpl.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/MinSideArbeidsgiverTjenesteImpl.java
@@ -11,13 +11,12 @@ import java.util.UUID;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import no.nav.familie.inntektsmelding.integrasjoner.altinn.AltinnRessurser;
 import no.nav.foreldrepenger.konfig.Environment;
 
 @ApplicationScoped
 class MinSideArbeidsgiverTjenesteImpl implements MinSideArbeidsgiverTjeneste {
 
-    static final String SERVICE_CODE = "4936";
-    static final String SERVICE_EDITION_CODE = "1";
     static final String SAK_STATUS_TEKST = "";
     static final String SAK_STATUS_TEKST_ARBEIDSGIVERINITIERT = "Mottatt - Se kvittering eller korriger refusjonskrav";
     static final Sendevindu VARSEL_SENDEVINDU = Sendevindu.LOEPENDE;
@@ -136,16 +135,18 @@ class MinSideArbeidsgiverTjenesteImpl implements MinSideArbeidsgiverTjeneste {
 
     private static MottakerInput lagAltinnMottakerInput() {
         return MottakerInput.builder()
-            .setAltinn(AltinnMottakerInput.builder().setServiceCode(SERVICE_CODE).setServiceEdition(SERVICE_EDITION_CODE).build())
+            .setAltinnRessurs(lagAltinnRessursMottakerInput())
             .build();
     }
 
     private static EksterntVarselInput lagEksternVarselAltinn(String varselTekst, Integer minutterForsinkelse) {
+        String tittel = "Nav trenger inntektsmelding";
         return EksterntVarselInput.builder()
-            .setAltinntjeneste(EksterntVarselAltinntjenesteInput.builder()
-                .setTittel("Nav trenger inntektsmelding")
-                .setInnhold(varselTekst)
-                .setMottaker(lagAltinnTjenesteMottakerInput())
+            .setAltinnressurs(EksterntVarselAltinnressursInput.builder()
+                .setEpostTittel(tittel)
+                .setEpostHtmlBody(varselTekst)
+                .setSmsTekst("%s. %s".formatted(tittel, varselTekst))
+                .setMottaker(lagAltinnRessursMottakerInput())
                 .setSendetidspunkt(SendetidspunktInput.builder()
                     .setTidspunkt(LocalDateTime.now().plusMinutes(minutterForsinkelse).toString())
                     .build())
@@ -154,18 +155,20 @@ class MinSideArbeidsgiverTjenesteImpl implements MinSideArbeidsgiverTjeneste {
     }
 
     private static PaaminnelseEksterntVarselInput lagPåminnelseVarselAltinn(String påminnelseTekst) {
+        String tittel = "Påminnelse: Nav trenger inntektsmelding";
         return PaaminnelseEksterntVarselInput.builder()
-            .setAltinntjeneste(PaaminnelseEksterntVarselAltinntjenesteInput.builder()
-                .setTittel("Påminnelse: Nav trenger inntektsmelding")
-                .setInnhold(påminnelseTekst)
-                .setMottaker(lagAltinnTjenesteMottakerInput())
+            .setAltinnressurs(PaaminnelseEksterntVarselAltinnressursInput.builder()
+                .setEpostTittel(tittel)
+                .setEpostHtmlBody(påminnelseTekst)
+                .setSmsTekst("%s. %s".formatted(tittel, påminnelseTekst))
+                .setMottaker(lagAltinnRessursMottakerInput())
                 .setSendevindu(VARSEL_SENDEVINDU)
                 .build())
             .build();
     }
 
-    private static AltinntjenesteMottakerInput lagAltinnTjenesteMottakerInput() {
-        return AltinntjenesteMottakerInput.builder().setServiceCode(SERVICE_CODE).setServiceEdition(SERVICE_EDITION_CODE).build();
+    private static AltinnRessursMottakerInput lagAltinnRessursMottakerInput() {
+        return AltinnRessursMottakerInput.builder().setRessursId(AltinnRessurser.ALTINN_TRE_RESSURS).build();
     }
 
     @Override

--- a/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/MinSideArbeidsgiverTjenesteImplTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/MinSideArbeidsgiverTjenesteImplTest.java
@@ -79,7 +79,8 @@ class MinSideArbeidsgiverTjenesteImplTest {
         var expectedNotifikasjonsTekst = "Du har en ny oppgave i AG-portalen";
         var expectedTittel = "Nav trenger inntektsmelding";
         var expectedEksternvarselTekst = "En ansatt har søkt pleiepenger sykt barn";
-        var expectedPåminnelseTekst = "Påmminnelse: En ansatt har søkt pleiepenger sykt barn";
+        var expectedPåminnelseTittel = "Påminnelse: Nav trenger inntektsmelding";
+        var expectedPåminnelseTekst = "Påminnelse: En ansatt har søkt pleiepenger sykt barn";
         var expectedNotifikasjonsLenke = "https://arbeidsgiver-portal.com";
         var expectedNotifikasjonsMerkelapp = Merkelapp.INNTEKTSMELDING_PSB;
 
@@ -122,11 +123,13 @@ class MinSideArbeidsgiverTjenesteImplTest {
         assertThat(nyOppgave.getEksterneVarsler().getFirst().getAltinnressurs()).isNotNull();
         assertThat(nyOppgave.getEksterneVarsler().getFirst().getAltinnressurs().getEpostTittel()).isEqualTo(expectedTittel);
         assertThat(nyOppgave.getEksterneVarsler().getFirst().getAltinnressurs().getEpostHtmlBody()).isEqualTo(expectedEksternvarselTekst);
+        assertThat(nyOppgave.getEksterneVarsler().getFirst().getAltinnressurs().getSmsTekst()).isEqualTo(expectedTittel + ". " + expectedEksternvarselTekst);
 
         assertThat(nyOppgave.getPaaminnelse()).isNotNull();
         assertThat(nyOppgave.getPaaminnelse().getEksterneVarsler()).isNotNull().hasSize(1);
         assertThat(nyOppgave.getPaaminnelse().getEksterneVarsler().getFirst().getAltinnressurs()).isNotNull();
         assertThat(nyOppgave.getPaaminnelse().getEksterneVarsler().getFirst().getAltinnressurs().getEpostHtmlBody()).isEqualTo(expectedPåminnelseTekst);
+        assertThat(nyOppgave.getPaaminnelse().getEksterneVarsler().getFirst().getAltinnressurs().getSmsTekst()).isEqualTo(expectedPåminnelseTittel + ". " + expectedPåminnelseTekst);
 
         assertThat(nyOppgave.getFrist()).isNull();
         assertThat(nyOppgave.getMottakere()).isEmpty();

--- a/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/MinSideArbeidsgiverTjenesteImplTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/MinSideArbeidsgiverTjenesteImplTest.java
@@ -1,7 +1,5 @@
 package no.nav.familie.inntektsmelding.integrasjoner.arbeidsgivernotifikasjon;
 
-import static no.nav.familie.inntektsmelding.integrasjoner.arbeidsgivernotifikasjon.MinSideArbeidsgiverTjenesteImpl.SERVICE_CODE;
-import static no.nav.familie.inntektsmelding.integrasjoner.arbeidsgivernotifikasjon.MinSideArbeidsgiverTjenesteImpl.SERVICE_EDITION_CODE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 
@@ -16,6 +14,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import no.nav.familie.inntektsmelding.integrasjoner.altinn.AltinnRessurser;
 
 @ExtendWith(MockitoExtension.class)
 class MinSideArbeidsgiverTjenesteImplTest {
@@ -77,6 +77,7 @@ class MinSideArbeidsgiverTjenesteImplTest {
         var expectedGrupperingsid = "id-som-knytter-sak-til-notifikasjon";
         var expectedVirksomhetsnummer = "2342342334";
         var expectedNotifikasjonsTekst = "Du har en ny oppgave i AG-portalen";
+        var expectedTittel = "Nav trenger inntektsmelding";
         var expectedEksternvarselTekst = "En ansatt har søkt pleiepenger sykt barn";
         var expectedPåminnelseTekst = "Påmminnelse: En ansatt har søkt pleiepenger sykt barn";
         var expectedNotifikasjonsLenke = "https://arbeidsgiver-portal.com";
@@ -104,8 +105,7 @@ class MinSideArbeidsgiverTjenesteImplTest {
         var nyOppgave = (NyOppgaveInput) input.get(inputKey);
 
         assertThat(nyOppgave.getMottaker()).isNotNull();
-        assertThat(nyOppgave.getMottaker().getAltinn().getServiceCode()).isEqualTo(SERVICE_CODE);
-        assertThat(nyOppgave.getMottaker().getAltinn().getServiceEdition()).isEqualTo(SERVICE_EDITION_CODE);
+        assertThat(nyOppgave.getMottaker().getAltinnRessurs().getRessursId()).isEqualTo(AltinnRessurser.ALTINN_TRE_RESSURS);
 
         assertThat(nyOppgave.getMetadata()).isNotNull();
         assertThat(nyOppgave.getMetadata().getEksternId()).isNotNull().isEqualTo(expectedEksternId);
@@ -119,13 +119,14 @@ class MinSideArbeidsgiverTjenesteImplTest {
         assertThat(nyOppgave.getNotifikasjon().getMerkelapp()).isEqualTo(expectedNotifikasjonsMerkelapp.getBeskrivelse());
 
         assertThat(nyOppgave.getEksterneVarsler()).hasSize(1);
-        assertThat(nyOppgave.getEksterneVarsler().getFirst().getAltinntjeneste()).isNotNull();
-        assertThat(nyOppgave.getEksterneVarsler().getFirst().getAltinntjeneste().getInnhold()).isEqualTo(expectedEksternvarselTekst);
+        assertThat(nyOppgave.getEksterneVarsler().getFirst().getAltinnressurs()).isNotNull();
+        assertThat(nyOppgave.getEksterneVarsler().getFirst().getAltinnressurs().getEpostTittel()).isEqualTo(expectedTittel);
+        assertThat(nyOppgave.getEksterneVarsler().getFirst().getAltinnressurs().getEpostHtmlBody()).isEqualTo(expectedEksternvarselTekst);
 
         assertThat(nyOppgave.getPaaminnelse()).isNotNull();
         assertThat(nyOppgave.getPaaminnelse().getEksterneVarsler()).isNotNull().hasSize(1);
-        assertThat(nyOppgave.getPaaminnelse().getEksterneVarsler().getFirst().getAltinntjeneste()).isNotNull();
-        assertThat(nyOppgave.getPaaminnelse().getEksterneVarsler().getFirst().getAltinntjeneste().getInnhold()).isEqualTo(expectedPåminnelseTekst);
+        assertThat(nyOppgave.getPaaminnelse().getEksterneVarsler().getFirst().getAltinnressurs()).isNotNull();
+        assertThat(nyOppgave.getPaaminnelse().getEksterneVarsler().getFirst().getAltinnressurs().getEpostHtmlBody()).isEqualTo(expectedPåminnelseTekst);
 
         assertThat(nyOppgave.getFrist()).isNull();
         assertThat(nyOppgave.getMottakere()).isEmpty();


### PR DESCRIPTION
### Behov / Bakgrunn
Gammel service code 4936 skrus av

### Løsning
Går over til å bruke den nye altinn 3 ressursen.
Skal bli tilsvarende som denne endringen i FP - https://github.com/navikt/fp-inntektsmelding/pull/305

---

### Sjekkliste for godkjenner

- [x] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [x] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [x] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
