### PR TITLE
fjerner bigquery lib og referanser da det ikke brukes etter sletting

### DIFF
--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -72,10 +72,6 @@ spec:
           - name: "pgaudit.log_parameter"
             value: "on"
         {{/if}}
-    bigQueryDatasets:
-      -  name: k9_inntektsmelding_statistikk_dataset
-         description: Inneholder tabeller for k9-inntektsmelding statistikk
-         permission: READWRITE
   tokenx:
     enabled: true
   azure:
@@ -127,8 +123,6 @@ spec:
       value: {{driftGruppeOid}}
     - name: gruppe.oid.saksbehandler
       value: {{saksbehandlerGruppeOid}}
-    - name: BIGQUERY_ENABLED
-      value: "true"
     - name: AUDITLOGGER_ENABLED
       value: "true"
     - name: AUDITLOGGER_VENDOR

--- a/pom.xml
+++ b/pom.xml
@@ -153,10 +153,6 @@
             <artifactId>kontrakt</artifactId>
         </dependency>
         <dependency>
-            <groupId>no.nav.k9.felles.integrasjon</groupId>
-            <artifactId>k9-bigquery-klient</artifactId>
-        </dependency>
-        <dependency>
             <groupId>no.nav.sif.abac</groupId>
             <artifactId>kontrakt</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,11 +74,6 @@
                 <version>${k9-sak.version}</version>
             </dependency>
             <dependency>
-                <groupId>no.nav.k9.felles.integrasjon</groupId>
-                <artifactId>k9-bigquery-klient</artifactId>
-                <version>${k9-felles.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>no.nav.sif.abac</groupId>
                 <artifactId>kontrakt</artifactId>
                 <version>${sif-abac-kontrakt.version}</version>


### PR DESCRIPTION
### Behov / Bakgrunn
BigQuery brukes ikke i dette repoet etter slettingen https://github.com/navikt/k9-inntektsmelding/pull/709

### Løsning

Rydder opp resten

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
