### PR TITLE
Fix: sett riktig repository id slik at github action publiserer kontrakt riktig

### DIFF
--- a/kontrakter/pom.xml
+++ b/kontrakter/pom.xml
@@ -46,7 +46,7 @@
 
 	<distributionManagement>
 		<repository>
-			<id>k9-inntektsmelding</id>
+			<id>github</id>
 			<name>Github navikt Maven Packages</name>
 			<url>https://maven.pkg.github.com/navikt/k9-inntektsmelding</url>
 		</repository>


### PR DESCRIPTION
### Behov / Bakgrunn
Github action feiler med 401 pga feil id.

### Løsning
Setter repository id til github slik vi gjør i andre repoer for k9.

---

### Sjekkliste for godkjenner

- [x] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [x] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [x] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
