### PR TITLE
TSFF-2706: Nye endepunkt for å hente forespørsler fra k9-inntektsmelding-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,11 +159,6 @@
             <version>${fp-graphql.version}</version>
         </dependency>
         <dependency>
-            <groupId>no.nav.k9.inntektsmelding</groupId>
-            <artifactId>k9-inntektsmelding-kontrakt</artifactId>
-            <version>${k9-inntektsmelding-kontrakt.version}</version>
-        </dependency>
-        <dependency>
             <groupId>no.nav.k9.sak</groupId>
             <artifactId>kontrakt</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
+        <k9-inntektsmelding-kontrakt.version>0.1.0</k9-inntektsmelding-kontrakt.version>
         <felles.version>7.8.2</felles.version>
         <prosesstask.version>5.2.6</prosesstask.version>
         <fp-kontrakter.version>9.4.34</fp-kontrakter.version>
@@ -69,6 +70,11 @@
                 <type>pom</type>
             </dependency>
             <dependency>
+                <groupId>no.nav.k9.inntektsmelding</groupId>
+                <artifactId>k9-inntektsmelding-kontrakt</artifactId>
+                <version>${k9-inntektsmelding-kontrakt.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>no.nav.k9.sak</groupId>
                 <artifactId>kontrakt</artifactId>
                 <version>${k9-sak.version}</version>
@@ -107,6 +113,10 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>no.nav.k9.inntektsmelding</groupId>
+            <artifactId>k9-inntektsmelding-kontrakt</artifactId>
+        </dependency>
         <dependency>
             <groupId>no.nav.foreldrepenger.felles</groupId>
             <artifactId>felles-oidc</artifactId>
@@ -147,6 +157,11 @@
             <groupId>no.nav.foreldrepenger.graphql</groupId>
             <artifactId>graphql-runtime</artifactId>
             <version>${fp-graphql.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.k9.inntektsmelding</groupId>
+            <artifactId>k9-inntektsmelding-kontrakt</artifactId>
+            <version>${k9-inntektsmelding-kontrakt.version}</version>
         </dependency>
         <dependency>
             <groupId>no.nav.k9.sak</groupId>

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselRepository.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/modell/ForespørselRepository.java
@@ -1,13 +1,16 @@
 package no.nav.familie.inntektsmelding.forespørsel.modell;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.Predicate;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -194,5 +197,47 @@ public class ForespørselRepository {
             .setParameter("fraDato", fraDato.atStartOfDay())
             .setParameter("tilDato", tilDato.plusDays(1).atStartOfDay());
         return query.getResultList();
+    }
+
+    public List<ForespørselEntitet> hentForespørslerFraFilter(String orgnr,
+                                                               AktørIdEntitet aktørId,
+                                                               ForespørselStatus status,
+                                                               Ytelsetype ytelseType,
+                                                               LocalDate fom,
+                                                               LocalDate tom) {
+        var cb = entityManager.getCriteriaBuilder();
+        var cq = cb.createQuery(ForespørselEntitet.class);
+        var root = cq.from(ForespørselEntitet.class);
+
+        var predicates = new ArrayList<Predicate>();
+        predicates.add(cb.equal(root.get("organisasjonsnummer"), Objects.requireNonNull(orgnr)));
+        if (aktørId != null) {
+            predicates.add(cb.equal(root.get("aktørId"), aktørId));
+        }
+        if (status != null) {
+            predicates.add(cb.equal(root.get("status"), status));
+        }
+        if (ytelseType != null) {
+            predicates.add(cb.equal(root.get("ytelseType"), ytelseType));
+        }
+        if (fom != null) {
+            predicates.add(cb.greaterThanOrEqualTo(root.get("opprettetTidspunkt"), fom.atStartOfDay()));
+        }
+        if (tom != null) {
+            predicates.add(cb.lessThan(root.get("opprettetTidspunkt"), tom.plusDays(1).atStartOfDay()));
+        }
+        cq.where(predicates.toArray(new Predicate[0]));
+        cq.orderBy(cb.asc(root.get("opprettetTidspunkt")));
+
+        var query = entityManager.createQuery(cq);
+        query.setMaxResults(1001);
+        var result = query.getResultList();
+        if (result.size() == 1001) {
+            LOG.warn("Hentet 1000 forespørsler for orgnr {}, men det finnes flere forespørsler som ikke er hentet ut", orgnr);
+            var redusertListe = new ArrayList<>(result);
+            redusertListe.removeLast();
+            return redusertListe;
+        }
+        return result;
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -149,6 +149,15 @@ public class ForespørselBehandlingTjeneste {
         return forespørselTjeneste.hentForespørsel(forespørselUUID);
     }
 
+    public List<ForespørselEntitet> hentForespørsler(ArbeidsgiverDto arbeidsgiver,
+                                                     AktørIdEntitet aktørId,
+                                                     ForespørselStatus status,
+                                                     Ytelsetype ytelseType,
+                                                     LocalDate fom,
+                                                     LocalDate tom) {
+        return forespørselTjeneste.hentForespørslerFraFilter(arbeidsgiver.ident(), aktørId, status, ytelseType, fom, tom);
+    }
+
     public List<ForespørselEntitet> finnAlleForespørsler(AktørIdEntitet aktørId, Ytelsetype ytelsetype, String orgnr) {
         return forespørselTjeneste.finnAlleForespørsler(aktørId, ytelsetype, orgnr);
     }

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTjeneste.java
@@ -10,6 +10,7 @@ import jakarta.inject.Inject;
 
 import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
 import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselRepository;
+import no.nav.familie.inntektsmelding.koder.ForespørselStatus;
 import no.nav.familie.inntektsmelding.koder.ForespørselType;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
@@ -95,5 +96,14 @@ public class ForespørselTjeneste {
 
     public void oppdaterForespørselMedNyeEtterspurtePerioder(UUID forespørselUuid, List<PeriodeDto> etterspurtePerioder) {
         forespørselRepository.oppdaterForespørselMedNyeEtterspurtePerioder(forespørselUuid, etterspurtePerioder);
+    }
+
+    public List<ForespørselEntitet> hentForespørslerFraFilter(String orgnr,
+                                                              AktørIdEntitet aktørId,
+                                                              ForespørselStatus status,
+                                                              Ytelsetype ytelseType,
+                                                              LocalDate fom,
+                                                              LocalDate tom) {
+        return forespørselRepository.hentForespørslerFraFilter(orgnr, aktørId, status, ytelseType, fom, tom);
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/imapi/forespørsel/ForespørselApiRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imapi/forespørsel/ForespørselApiRest.java
@@ -1,0 +1,87 @@
+package no.nav.familie.inntektsmelding.imapi.forespørsel;
+
+import java.util.UUID;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.familie.inntektsmelding.server.auth.api.AutentisertMedAzure;
+import no.nav.familie.inntektsmelding.server.auth.api.Tilgangskontrollert;
+import no.nav.familie.inntektsmelding.server.tilgangsstyring.Tilgang;
+import no.nav.familie.inntektsmelding.typer.dto.ArbeidsgiverDto;
+import no.nav.k9.inntektsmelding.imapi.forespørsel.HentForespørselerRequest;
+import no.nav.k9.inntektsmelding.imapi.forespørsel.HentForespørslerResponse;
+
+@AutentisertMedAzure
+@ApplicationScoped
+@Transactional
+@Path(ForespørselApiRest.BASE_PATH)
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class ForespørselApiRest {
+    public static final String BASE_PATH = "/imapi/foresporsel";
+    private static final Logger LOG = LoggerFactory.getLogger(ForespørselApiRest.class);
+
+    private ForespørselApiTjeneste forespørselApiTjeneste;
+    private Tilgang tilgang;
+
+    ForespørselApiRest() {
+        // Kun for CDI-proxy
+    }
+
+    @Inject
+    public ForespørselApiRest(ForespørselApiTjeneste forespørselApiTjeneste,
+                              Tilgang tilgang) {
+        this.forespørselApiTjeneste = forespørselApiTjeneste;
+        this.tilgang = tilgang;
+    }
+
+    @GET
+    @Path("/hent/{forespørselUuid}")
+    @Tilgangskontrollert
+    public Response hentForespørsel(@Valid @PathParam("forespørselUuid") UUID forespørselUuId) {
+        sjekkErSystemkall();
+
+        var forespørselDto = forespørselApiTjeneste.hentForesørselDto(forespørselUuId);
+
+        if (forespørselDto.isEmpty()) {
+            LOG.warn("Forespørsel med uuid {} finnes ikke", forespørselUuId);
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        return forespørselDto.map(Response::ok).orElse(Response.status(Response.Status.NOT_FOUND)).build();
+    }
+
+    @POST
+    @Path("/hent/foresporsler")
+    @Tilgangskontrollert
+    public Response hentForespørsler(@Valid @NotNull HentForespørselerRequest filterRequest) {
+        sjekkErSystemkall();
+        var dtoer = forespørselApiTjeneste.hentForespørslerDto(
+            new ArbeidsgiverDto(filterRequest.orgnr().orgnr()),
+            filterRequest.fnr(),
+            filterRequest.status(),
+            filterRequest.ytelseType(),
+            filterRequest.fom(),
+            filterRequest.tom());
+        return Response.ok(new HentForespørslerResponse(dtoer)).build();
+    }
+
+    private void sjekkErSystemkall() {
+        tilgang.sjekkErSystembruker();
+    }
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/imapi/forespørsel/ForespørselApiTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imapi/forespørsel/ForespørselApiTjeneste.java
@@ -1,0 +1,128 @@
+package no.nav.familie.inntektsmelding.imapi.forespørsel;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
+import no.nav.familie.inntektsmelding.koder.ForespørselStatus;
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.familie.inntektsmelding.typer.dto.ArbeidsgiverDto;
+import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
+import no.nav.k9.inntektsmelding.felles.ForespørselStatusDto;
+import no.nav.k9.inntektsmelding.felles.FødselsnummerDto;
+import no.nav.k9.inntektsmelding.felles.OrganisasjonsnummerDto;
+import no.nav.k9.inntektsmelding.felles.PeriodeDto;
+import no.nav.k9.inntektsmelding.felles.YtelseTypeDto;
+import no.nav.k9.inntektsmelding.imapi.forespørsel.ForespørselDto;
+
+@ApplicationScoped
+public class ForespørselApiTjeneste {
+    private PersonTjeneste personTjeneste;
+    private ForespørselBehandlingTjeneste forespørselBehandlingTjeneste;
+
+    ForespørselApiTjeneste() {
+        // CDI
+    }
+
+    @Inject
+    public ForespørselApiTjeneste(PersonTjeneste personTjeneste,
+                                  ForespørselBehandlingTjeneste forespørselBehandlingTjeneste) {
+        this.personTjeneste = personTjeneste;
+        this.forespørselBehandlingTjeneste = forespørselBehandlingTjeneste;
+    }
+
+    public Optional<ForespørselDto> hentForesørselDto(UUID forespørselUuid) {
+
+        return forespørselBehandlingTjeneste.hentForespørsel(forespørselUuid)
+            .map(forespørsel -> {
+                var fnr = personTjeneste.finnPersonIdentForAktørId(forespørsel.getAktørId());
+                return mapTilResponseDto(forespørsel, fnr);
+            });
+    }
+
+    public List<ForespørselDto> hentForespørslerDto(ArbeidsgiverDto arbeidsgiverDto,
+                                                    FødselsnummerDto fnrDto,
+                                                    ForespørselStatusDto statusDto,
+                                                    YtelseTypeDto ytelseTypeDto,
+                                                    LocalDate fom,
+                                                    LocalDate tom) {
+        AktørIdEntitet aktørId = fnrDto != null
+                      ? personTjeneste.finnAktørIdForPersonIdent(fnrDto.fnr()).orElse(null)
+                      : null;
+        ForespørselStatus status = statusDto != null ? mapForespørselStatus(statusDto) : null;
+        Ytelsetype ytelsetype = ytelseTypeDto != null ? mapYtelsetype(ytelseTypeDto) : null;
+
+        List<ForespørselEntitet> forespørsler = forespørselBehandlingTjeneste.hentForespørsler(arbeidsgiverDto, aktørId, status, ytelsetype, fom, tom);
+
+        Set<AktørIdEntitet> aktørIder = forespørsler.stream().map(ForespørselEntitet::getAktørId).collect(Collectors.toSet());
+        Map<AktørIdEntitet, PersonIdent> aktørIdPersonIdentMap = personTjeneste.finnPersonIdentForAktørIdBolk(aktørIder);
+
+        return forespørsler.stream()
+            .map(f -> mapTilResponseDto(f, aktørIdPersonIdentMap.get(f.getAktørId())))
+            .toList();
+    }
+
+    private ForespørselDto mapTilResponseDto(ForespørselEntitet forespørsel, PersonIdent personIdent) {
+        if (personIdent == null) {
+            throw new IllegalArgumentException("Finner ikke fødselsnummer for aktørId " + forespørsel.getAktørId());
+        }
+
+        List<PeriodeDto> etterspurtePerioder = forespørsel.getEtterspurtePerioder().stream()
+            .map(p -> new PeriodeDto(p.fom(), p.tom()))
+            .toList();
+
+        return new ForespørselDto(forespørsel.getUuid(),
+            new OrganisasjonsnummerDto(forespørsel.getOrganisasjonsnummer()),
+            new FødselsnummerDto(personIdent.getIdent()),
+            forespørsel.getSkjæringstidspunkt(),
+            mapYtelsetype(forespørsel.getYtelseType()),
+            mapForespørselStatus(forespørsel.getStatus()),
+            etterspurtePerioder,
+            forespørsel.getOpprettetTidspunkt());
+    }
+
+    static YtelseTypeDto mapYtelsetype(Ytelsetype ytelseType) {
+        return switch (ytelseType) {
+            case PLEIEPENGER_SYKT_BARN -> YtelseTypeDto.PLEIEPENGER_SYKT_BARN;
+            case PLEIEPENGER_NÆRSTÅENDE -> YtelseTypeDto.PLEIEPENGER_I_LIVETS_SLUTTFASE;
+            case OPPLÆRINGSPENGER -> YtelseTypeDto.OPPLÆRINGSPENGER;
+            case OMSORGSPENGER -> YtelseTypeDto.OMSORGSPENGER;
+        };
+    }
+
+    static Ytelsetype mapYtelsetype(YtelseTypeDto ytelseTypeDto) {
+        return switch (ytelseTypeDto) {
+            case PLEIEPENGER_SYKT_BARN -> Ytelsetype.PLEIEPENGER_SYKT_BARN;
+            case PLEIEPENGER_I_LIVETS_SLUTTFASE -> Ytelsetype.PLEIEPENGER_NÆRSTÅENDE;
+            case OPPLÆRINGSPENGER -> Ytelsetype.OPPLÆRINGSPENGER;
+            case OMSORGSPENGER -> Ytelsetype.OMSORGSPENGER;
+        };
+    }
+
+    static ForespørselStatusDto mapForespørselStatus(ForespørselStatus status) {
+        return switch (status) {
+            case UNDER_BEHANDLING -> ForespørselStatusDto.UNDER_BEHANDLING;
+            case FERDIG -> ForespørselStatusDto.FERDIG;
+            case UTGÅTT -> ForespørselStatusDto.UTGÅTT;
+        };
+    }
+
+    static ForespørselStatus mapForespørselStatus(ForespørselStatusDto statusDto) {
+        return switch (statusDto) {
+            case UNDER_BEHANDLING -> ForespørselStatus.UNDER_BEHANDLING;
+            case FERDIG -> ForespørselStatus.FERDIG;
+            case UTGÅTT -> ForespørselStatus.UTGÅTT;
+        };
+    }
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/imapi/forespørsel/ForespørselApiTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imapi/forespørsel/ForespørselApiTjeneste.java
@@ -46,8 +46,8 @@ public class ForespørselApiTjeneste {
 
         return forespørselBehandlingTjeneste.hentForespørsel(forespørselUuid)
             .map(forespørsel -> {
-                var fnr = personTjeneste.finnPersonIdentForAktørId(forespørsel.getAktørId());
-                return mapTilResponseDto(forespørsel, fnr);
+                var personIdent = personTjeneste.finnPersonIdentForAktørId(forespørsel.getAktørId());
+                return mapTilResponseDto(forespørsel, personIdent);
             });
     }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/person/PersonTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/person/PersonTjeneste.java
@@ -2,8 +2,11 @@ package no.nav.familie.inntektsmelding.integrasjoner.person;
 
 import java.net.SocketTimeoutException;
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -89,6 +92,18 @@ public class PersonTjeneste {
             case KVINNE -> Kjønn.KVINNE;
             default -> Kjønn.UKJENT;
         };
+    }
+
+    public Optional<AktørIdEntitet> finnAktørIdForPersonIdent(String fnr) {
+        return finnAktørIdForIdent(new PersonIdent(fnr));
+    }
+
+    public Map<AktørIdEntitet, PersonIdent> finnPersonIdentForAktørIdBolk(Set<AktørIdEntitet> aktørIder) {
+        var result = new HashMap<AktørIdEntitet, PersonIdent>();
+        for (var aktørId : aktørIder) {
+            hentPersonidentForAktørId(aktørId).ifPresent(ident -> result.put(aktørId, ident));
+        }
+        return result;
     }
 
     private Optional<AktørIdEntitet> finnAktørIdForIdent(PersonIdent personIdent) {

--- a/src/main/java/no/nav/familie/inntektsmelding/typer/dto/FødselsnummerDto.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/typer/dto/FødselsnummerDto.java
@@ -1,0 +1,14 @@
+package no.nav.familie.inntektsmelding.typer.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public record FødselsnummerDto(@JsonValue @NotNull @Pattern(regexp = "^\\d{11}$") @NotNull String fnr) {
+    @Override
+    public String toString() {
+        return "";
+    }
+}
+

--- a/src/test/java/no/nav/familie/inntektsmelding/imapi/forespørsel/ForespørselApiRestTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imapi/forespørsel/ForespørselApiRestTest.java
@@ -1,0 +1,92 @@
+package no.nav.familie.inntektsmelding.imapi.forespørsel;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import no.nav.familie.inntektsmelding.server.tilgangsstyring.Tilgang;
+import no.nav.familie.inntektsmelding.typer.dto.ArbeidsgiverDto;
+import no.nav.k9.inntektsmelding.felles.ForespørselStatusDto;
+import no.nav.k9.inntektsmelding.felles.FødselsnummerDto;
+import no.nav.k9.inntektsmelding.felles.OrganisasjonsnummerDto;
+import no.nav.k9.inntektsmelding.felles.YtelseTypeDto;
+import no.nav.k9.inntektsmelding.imapi.forespørsel.ForespørselDto;
+import no.nav.k9.inntektsmelding.imapi.forespørsel.HentForespørselerRequest;
+import no.nav.k9.inntektsmelding.imapi.forespørsel.HentForespørslerResponse;
+
+@ExtendWith(MockitoExtension.class)
+class ForespørselApiRestTest {
+    private static final String ORGNUMMER = "974760673";
+
+    private ForespørselApiRest forespørselApiRest;
+    @Mock
+    private Tilgang tilgang;
+    @Mock
+    private ForespørselApiTjeneste forespørselApiTjeneste;
+
+    @BeforeEach
+    void setUp() {
+        this.forespørselApiRest = new ForespørselApiRest(forespørselApiTjeneste, tilgang);
+    }
+
+    @Test
+    void skal_hente_forespørsel() {
+        var forespørselUuid = UUID.randomUUID();
+        var forventetDto = lagForespørselDto(forespørselUuid);
+        when(forespørselApiTjeneste.hentForesørselDto(forespørselUuid)).thenReturn(Optional.of(forventetDto));
+
+        var response = forespørselApiRest.hentForespørsel(forespørselUuid);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK_200);
+        assertThat(response.getEntity()).isEqualTo(forventetDto);
+        verify(forespørselApiTjeneste).hentForesørselDto(forespørselUuid);
+    }
+
+    @Test
+    void skal_returnere_404_når_forespørsel_ikke_finnes() {
+        var forespørselUuid = UUID.randomUUID();
+        when(forespørselApiTjeneste.hentForesørselDto(forespørselUuid)).thenReturn(Optional.empty());
+
+        var response = forespørselApiRest.hentForespørsel(forespørselUuid);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND_404);
+    }
+
+    @Test
+    void skal_hente_forespørsler() {
+        var forespørselUuid = UUID.randomUUID();
+        var forespørselDto = lagForespørselDto(forespørselUuid);
+        var filterRequest = new HentForespørselerRequest(new OrganisasjonsnummerDto(ORGNUMMER), null, null, null, null, null);
+        when(forespørselApiTjeneste.hentForespørslerDto(new ArbeidsgiverDto(ORGNUMMER), null, null, null, null, null))
+            .thenReturn(List.of(forespørselDto));
+
+        var response = forespørselApiRest.hentForespørsler(filterRequest);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK_200);
+        assertThat(((HentForespørslerResponse) response.getEntity()).forespørsler()).asList().containsExactly(forespørselDto);
+    }
+
+    private ForespørselDto lagForespørselDto(UUID uuid) {
+        return new ForespørselDto(uuid,
+            new OrganisasjonsnummerDto(ORGNUMMER),
+            new FødselsnummerDto("11111111111"),
+            LocalDate.now(),
+            YtelseTypeDto.PLEIEPENGER_SYKT_BARN,
+            ForespørselStatusDto.UNDER_BEHANDLING,
+            List.of(),
+            LocalDateTime.now());
+    }
+}

--- a/src/test/java/no/nav/familie/inntektsmelding/imapi/forespørsel/ForespørselApiTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imapi/forespørsel/ForespørselApiTjenesteTest.java
@@ -1,0 +1,89 @@
+package no.nav.familie.inntektsmelding.imapi.forespørsel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
+import no.nav.familie.inntektsmelding.koder.ForespørselType;
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.familie.inntektsmelding.typer.dto.ArbeidsgiverDto;
+import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
+
+@ExtendWith(MockitoExtension.class)
+class ForespørselApiTjenesteTest {
+    @Mock
+    private PersonTjeneste personTjeneste;
+    @Mock
+    private ForespørselBehandlingTjeneste forespørselBehandlingTjeneste;
+
+    private ForespørselApiTjeneste forespørselApiTjeneste;
+
+    @BeforeEach
+    void setUp() {
+        this.forespørselApiTjeneste = new ForespørselApiTjeneste(personTjeneste, forespørselBehandlingTjeneste);
+    }
+
+    @Test
+    void skal_returnere_forespørsel_med_fnr() {
+        var aktørId = new AktørIdEntitet("1234567890123");
+        var fnr = new PersonIdent("11111111111");
+        var orgnr = "999999999";
+        var forespørsel = ForespørselEntitet.builder()
+            .medOrganisasjonsnummer(orgnr)
+            .medSkjæringstidspunkt(LocalDate.now())
+            .medAktørId(aktørId)
+            .medYtelseType(Ytelsetype.PLEIEPENGER_SYKT_BARN)
+            .medForespørselType(ForespørselType.BESTILT_AV_FAGSYSTEM)
+            .build();
+        var forespørselUuid = UUID.randomUUID();
+        when(forespørselBehandlingTjeneste.hentForespørsel(forespørselUuid)).thenReturn(Optional.of(forespørsel));
+        when(personTjeneste.finnPersonIdentForAktørId(aktørId)).thenReturn(fnr);
+
+        var dto = forespørselApiTjeneste.hentForesørselDto(forespørselUuid);
+
+        assertThat(dto).isPresent();
+        assertThat(dto.get().fødselsnummer().fnr()).isEqualTo(fnr.getIdent());
+        assertThat(dto.get().orgnummer().orgnr()).isEqualTo(orgnr);
+    }
+
+    @Test
+    void skal_filtrere_forespørsler_på_orgnr() {
+        var aktørId = new AktørIdEntitet("1234567890123");
+        var fnr = new PersonIdent("11111111111");
+        var orgnr = "999999999";
+        var arbeidsgiverDto = new ArbeidsgiverDto(orgnr);
+        var forespørsel = ForespørselEntitet.builder()
+            .medOrganisasjonsnummer(orgnr)
+            .medSkjæringstidspunkt(LocalDate.now())
+            .medAktørId(aktørId)
+            .medYtelseType(Ytelsetype.PLEIEPENGER_SYKT_BARN)
+            .medForespørselType(ForespørselType.BESTILT_AV_FAGSYSTEM)
+            .build();
+        when(forespørselBehandlingTjeneste.hentForespørsler(arbeidsgiverDto, null, null, null, null, null))
+            .thenReturn(List.of(forespørsel));
+        when(personTjeneste.finnPersonIdentForAktørIdBolk(Set.of(aktørId)))
+            .thenReturn(Map.of(aktørId, fnr));
+
+        var dtoer = forespørselApiTjeneste.hentForespørslerDto(arbeidsgiverDto, null, null, null, null, null);
+
+        assertThat(dtoer).hasSize(1);
+        assertThat(dtoer.getFirst().fødselsnummer().fnr()).isEqualTo(fnr.getIdent());
+        assertThat(dtoer.getFirst().orgnummer().orgnr()).isEqualTo(orgnr);
+    }
+}

--- a/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/person/PersonTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/person/PersonTjenesteTest.java
@@ -2,12 +2,17 @@ package no.nav.familie.inntektsmelding.integrasjoner.person;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,7 +23,10 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
 import no.nav.pdl.Foedselsdato;
+import no.nav.pdl.IdentInformasjon;
+import no.nav.pdl.Identliste;
 import no.nav.pdl.Navn;
 import no.nav.pdl.Person;
 import no.nav.pdl.Telefonnummer;
@@ -96,5 +104,49 @@ class PersonTjenesteTest {
         when(KontekstHolder.getKontekst()).thenReturn(kontekst);
 
         assertThrows(IllegalStateException.class, () -> personTjeneste.hentInnloggetPerson(ytelseType));
+    }
+
+    @Test
+    void finnAktørIdForPersonIdent_skal_returnere_aktørId_når_pdl_returnerer_verdi() {
+        var fnr = "11839798115";
+        var aktørIdVerdi = "1234567890123";
+        when(pdlKlientMock.hentAktørIdForPersonIdent(eq(fnr), eq(true))).thenReturn(Optional.of(aktørIdVerdi));
+
+        var result = personTjeneste.finnAktørIdForPersonIdent(fnr);
+
+        assertTrue(result.isPresent());
+        assertEquals(aktørIdVerdi, result.get().getAktørId());
+    }
+
+    @Test
+    void finnAktørIdForPersonIdent_skal_returnere_tomt_når_pdl_ikke_finner_fnr() {
+        var fnr = "11839798115";
+        when(pdlKlientMock.hentAktørIdForPersonIdent(eq(fnr), eq(true))).thenReturn(Optional.empty());
+
+        var result = personTjeneste.finnAktørIdForPersonIdent(fnr);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void finnPersonIdentForAktørIdBolk_skal_returnere_mapping_og_utelate_ukjente_aktørIder() {
+        var aktørId1 = new AktørIdEntitet("1111111111111");
+        var aktørId2 = new AktørIdEntitet("2222222222222");
+        var fnr1 = "11839798115";
+
+        var identMedFnr = new IdentInformasjon();
+        identMedFnr.setIdent(fnr1);
+        var identlisteMedFnr = mock(Identliste.class);
+        when(identlisteMedFnr.getIdenter()).thenReturn(List.of(identMedFnr));
+
+        var identlisteUten = mock(Identliste.class);
+        when(identlisteUten.getIdenter()).thenReturn(List.of());
+
+        when(pdlKlientMock.hentIdenter(any(), any())).thenReturn(identlisteMedFnr, identlisteUten);
+
+        var result = personTjeneste.finnPersonIdentForAktørIdBolk(Set.of(aktørId1, aktørId2));
+
+        assertEquals(1, result.size());
+        assertTrue(result.containsValue(new PersonIdent(fnr1)));
     }
 }


### PR DESCRIPTION
### Behov / Bakgrunn
Det nye k9-inntektsmelding-api repoet som skal kommunisere med lønn og personalsystem (LPS) trenger å kalle k9-inntektsmelding for å hente forespørsler og, inntektsmeldinger og å sende inntektsmeldinger. Dette har allerede foreldrepenger løst, så vi henter inspirasjon derfra.

I forrige pr publiserte vi kontraktene: https://github.com/navikt/k9-inntektsmelding/pull/714

Nå oppretter vi endepunktene, tilsvarende som foreledrepenger har gjort. 

Jira: https://nav.atlassian.net/browse/TSFF-2706

### Løsning
Kopiert over endepunktene fra fp-inntektsmelding og tilpasset til k9.

### Andre endringer
Lagt til tester i `PersonTjenesteTest` for de nye metodene `finnAktørIdForPersonIdent` og `finnPersonIdentForAktørIdBolk`:
- Verifiserer fnr → aktørId når PDL returnerer verdi
- Verifiserer fnr → tomt resultat når PDL ikke finner fnr
- Verifiserer bolk-oppslag med mapping og at ukjente aktørIder (ingen PDL-treff) utelates fra resultatet

---

### Sjekkliste for godkjenner

- [x] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [x] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [x] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres