### PR TITLE
Fjern typer fra InntektsmeldingDto som vi ikke trenger

### DIFF
--- a/kontrakter/src/main/java/no/nav/k9/inntektsmelding/felles/InnsendingstypeDto.java
+++ b/kontrakter/src/main/java/no/nav/k9/inntektsmelding/felles/InnsendingstypeDto.java
@@ -1,6 +1,0 @@
-package no.nav.k9.inntektsmelding.felles;
-
-public enum InnsendingstypeDto {
-    FORESPURT,
-    ARBEIDSGIVER_INITIERT
-}

--- a/kontrakter/src/main/java/no/nav/k9/inntektsmelding/felles/InnsendingsårsakDto.java
+++ b/kontrakter/src/main/java/no/nav/k9/inntektsmelding/felles/InnsendingsårsakDto.java
@@ -1,6 +1,0 @@
-package no.nav.k9.inntektsmelding.felles;
-
-public enum InnsendingsårsakDto {
-    NY,
-    ENDRING
-}

--- a/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/inntektsmelding/InntektsmeldingDto.java
+++ b/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/inntektsmelding/InntektsmeldingDto.java
@@ -16,8 +16,6 @@ import no.nav.k9.inntektsmelding.felles.AvsenderSystemDto;
 import no.nav.k9.inntektsmelding.felles.BortfaltNaturalytelseDto;
 import no.nav.k9.inntektsmelding.felles.EndringsårsakerDto;
 import no.nav.k9.inntektsmelding.felles.FødselsnummerDto;
-import no.nav.k9.inntektsmelding.felles.InnsendingstypeDto;
-import no.nav.k9.inntektsmelding.felles.InnsendingsårsakDto;
 import no.nav.k9.inntektsmelding.felles.KontaktpersonDto;
 import no.nav.k9.inntektsmelding.felles.OrganisasjonsnummerDto;
 import no.nav.k9.inntektsmelding.felles.RefusjonDto;
@@ -31,8 +29,6 @@ public record InntektsmeldingDto(
     @NotNull @Valid OrganisasjonsnummerDto arbeidsgiver,
     @NotNull @Valid KontaktpersonDto kontaktperson,
     @NotNull LocalDate startdato,
-    @NotNull @Valid InnsendingstypeDto innsendingstype,
-    @NotNull @Valid InnsendingsårsakDto innsendingsårsak,
     @NotNull @Min(0) @Max(Integer.MAX_VALUE) @Digits(integer = 20, fraction = 2) BigDecimal inntekt,
     @NotNull LocalDateTime innsendtTidspunkt,
     @Min(0) @Max(Integer.MAX_VALUE) @Digits(integer = 20, fraction = 2) BigDecimal refusjonPrMnd,


### PR DESCRIPTION
### Behov / Bakgrunn
Fjerner typer som foreldrepenger ikke bruker. Kan legge dem tilbake hvis det viser seg å bli behov for dem.

### Løsning
Fjerner 🔥 

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
