### PR TITLE
 TSFF-2729: Nye endepunkt for å hente og motta innetktsmelding fra k9-inntektsmelding-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <k9-inntektsmelding-kontrakt.version>0.1.0</k9-inntektsmelding-kontrakt.version>
+        <k9-inntektsmelding-kontrakt.version>0.1.1</k9-inntektsmelding-kontrakt.version>
         <felles.version>7.8.2</felles.version>
         <prosesstask.version>5.2.6</prosesstask.version>
         <fp-kontrakter.version>9.4.34</fp-kontrakter.version>

--- a/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMapper.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMapper.java
@@ -1,0 +1,218 @@
+package no.nav.familie.inntektsmelding.imapi.inntektsmelding;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.BortaltNaturalytelseEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.EndringsårsakEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.KontaktpersonEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.LpsSystemInfoEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.RefusjonsendringEntitet;
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
+import no.nav.familie.inntektsmelding.koder.Endringsårsak;
+import no.nav.familie.inntektsmelding.koder.ForespørselType;
+import no.nav.familie.inntektsmelding.koder.InntektsmeldingType;
+import no.nav.familie.inntektsmelding.koder.Kildesystem;
+import no.nav.familie.inntektsmelding.koder.NaturalytelseType;
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
+import no.nav.k9.inntektsmelding.felles.AvsenderSystemDto;
+import no.nav.k9.inntektsmelding.felles.BortfaltNaturalytelseDto;
+import no.nav.k9.inntektsmelding.felles.EndringsårsakerDto;
+import no.nav.k9.inntektsmelding.felles.FødselsnummerDto;
+import no.nav.k9.inntektsmelding.felles.KontaktpersonDto;
+import no.nav.k9.inntektsmelding.felles.NaturalytelsetypeDto;
+import no.nav.k9.inntektsmelding.felles.OrganisasjonsnummerDto;
+import no.nav.k9.inntektsmelding.felles.RefusjonDto;
+import no.nav.k9.inntektsmelding.felles.YtelseTypeDto;
+import no.nav.k9.inntektsmelding.imapi.inntektsmelding.InntektsmeldingDto;
+import no.nav.k9.inntektsmelding.imapi.inntektsmelding.SendInntektsmeldingRequest;
+import no.nav.vedtak.konfig.Tid;
+
+class InntektsmeldingApiMapper {
+
+    private InntektsmeldingApiMapper() {}
+
+    static InntektsmeldingEntitet mapTilEntitet(SendInntektsmeldingRequest request,
+                                                AktørIdEntitet aktørId,
+                                                ForespørselEntitet forespørsel) {
+        var refusjonPrMnd = finnFørsteRefusjon(request.refusjon(), request.startdato()).orElse(null);
+        var opphørsdato = refusjonPrMnd == null ? null : finnOpphørsdato(request.refusjon(), request.startdato()).orElse(Tid.TIDENES_ENDE);
+
+        var lpsSystem = LpsSystemInfoEntitet.builder()
+            .medNavn(request.avsenderSystem().systemNavn())
+            .medVersjon(request.avsenderSystem().systemVersjon())
+            .build();
+
+        return InntektsmeldingEntitet.builder()
+            .medAktørId(aktørId)
+            .medArbeidsgiverIdent(request.organisasjonsnummer().orgnr())
+            .medMånedInntekt(request.inntekt())
+            .medKildesystem(Kildesystem.LØNN_OG_PERSONAL_SYSTEM)
+            .medInntektsmeldingType(utledInntektsmeldingType(forespørsel.getForespørselType()))
+            .medMånedRefusjon(refusjonPrMnd)
+            .medRefusjonOpphørsdato(opphørsdato)
+            .medStartDato(request.startdato())
+            .medYtelsetype(mapYtelsetype(request.ytelseType()))
+            .medKontaktperson(new KontaktpersonEntitet(request.kontaktperson().navn(), request.kontaktperson().telefonnummer()))
+            .medEndringsårsaker(mapEndringsårsaker(request.endringAvInntektÅrsaker()))
+            .medBortfaltNaturalytelser(mapBortfalteNaturalytelser(request.bortfaltNaturalytelsePerioder()))
+            .medRefusjonsendringer(mapRefusjonsendringer(request.startdato(), opphørsdato, request.refusjon()))
+            .medLpsSystemInfo(lpsSystem)
+            .medForespørsel(forespørsel)
+            .build();
+    }
+
+    static InntektsmeldingDto mapFraEntitet(InntektsmeldingEntitet inntektsmelding, PersonIdent personIdent) {
+        var forespørsel = inntektsmelding.getForespørsel();
+        return new InntektsmeldingDto(
+            inntektsmelding.getUuid(),
+            forespørsel.getUuid(),
+            new FødselsnummerDto(personIdent.getIdent()),
+            mapYtelseTypeTilKontrakt(inntektsmelding.getYtelsetype()),
+            new OrganisasjonsnummerDto(inntektsmelding.getArbeidsgiverIdent()),
+            mapKontaktperson(inntektsmelding),
+            inntektsmelding.getStartDato(),
+            inntektsmelding.getMånedInntekt(),
+            inntektsmelding.getOpprettetTidspunkt(),
+            inntektsmelding.getMånedRefusjon(),
+            inntektsmelding.getOpphørsdatoRefusjon(),
+            utledAvsenderSystem(inntektsmelding),
+            mapRefusjonsendringerTilKontrakt(inntektsmelding),
+            mapBortfalteNaturalytelserTilKontrakt(inntektsmelding.getBorfalteNaturalYtelser()),
+            mapEndringsårsakerTilKontrakt(inntektsmelding.getEndringsårsaker())
+        );
+    }
+
+    private static KontaktpersonDto mapKontaktperson(InntektsmeldingEntitet inntektsmelding) {
+        return new KontaktpersonDto(inntektsmelding.getKontaktperson().getNavn(), inntektsmelding.getKontaktperson().getTelefonnummer());
+    }
+
+    private static InntektsmeldingType utledInntektsmeldingType(ForespørselType forespørselType) {
+        return switch (forespørselType) {
+            case ARBEIDSGIVERINITIERT_NYANSATT -> InntektsmeldingType.ARBEIDSGIVERINITIERT_NYANSATT;
+            case ARBEIDSGIVERINITIERT_UREGISTRERT -> InntektsmeldingType.ARBEIDSGIVERINITIERT_UREGISTRERT;
+            case OMSORGSPENGER_REFUSJON -> InntektsmeldingType.OMSORGSPENGER_REFUSJON;
+            case BESTILT_AV_FAGSYSTEM, BESTILT_AV_SAKSBEHANDLER -> InntektsmeldingType.ORDINÆR;
+        };
+    }
+
+    private static AvsenderSystemDto utledAvsenderSystem(InntektsmeldingEntitet entitet) {
+        if (entitet.getLpsSystem() != null) {
+            return new AvsenderSystemDto(entitet.getLpsSystem().getNavn(), entitet.getLpsSystem().getVersjon());
+        }
+        return new AvsenderSystemDto("NAV_NO", "1.0");
+    }
+
+    private static Ytelsetype mapYtelsetype(YtelseTypeDto ytelseTypeDto) {
+        return switch (ytelseTypeDto) {
+            case OMSORGSPENGER -> Ytelsetype.OMSORGSPENGER;
+            case OPPLÆRINGSPENGER -> Ytelsetype.OPPLÆRINGSPENGER;
+            case PLEIEPENGER_SYKT_BARN -> Ytelsetype.PLEIEPENGER_SYKT_BARN;
+            case PLEIEPENGER_I_LIVETS_SLUTTFASE -> Ytelsetype.PLEIEPENGER_NÆRSTÅENDE;
+        };
+    }
+
+    private static YtelseTypeDto mapYtelseTypeTilKontrakt(Ytelsetype ytelsetype) {
+        return switch (ytelsetype) {
+            case OMSORGSPENGER -> YtelseTypeDto.OMSORGSPENGER;
+            case OPPLÆRINGSPENGER -> YtelseTypeDto.OPPLÆRINGSPENGER;
+            case PLEIEPENGER_SYKT_BARN -> YtelseTypeDto.PLEIEPENGER_SYKT_BARN;
+            case PLEIEPENGER_NÆRSTÅENDE -> YtelseTypeDto.PLEIEPENGER_I_LIVETS_SLUTTFASE;
+        };
+    }
+
+    private static Optional<BigDecimal> finnFørsteRefusjon(List<RefusjonDto> refusjon, LocalDate startdato) {
+        if (refusjon.isEmpty()) {
+            return Optional.empty();
+        }
+        var refusjonPåStartdato = refusjon.stream().filter(r -> r.fom().equals(startdato)).toList();
+        if (refusjonPåStartdato.size() != 1) {
+            throw new IllegalStateException("Forventer kun 1 refusjon som starter på startdato, fant " + refusjonPåStartdato.size());
+        }
+        return Optional.of(refusjonPåStartdato.getFirst().beløp());
+    }
+
+    private static Optional<LocalDate> finnOpphørsdato(List<RefusjonDto> refusjon, LocalDate startdato) {
+        // Hvis siste endring setter refusjon til 0 er det å regne som opphør av refusjon,
+        // setter dagen før denne endringen som opphørsdato
+        return refusjon.stream()
+            .filter(r -> !r.fom().equals(startdato))
+            .max(Comparator.comparing(RefusjonDto::fom))
+            .filter(r -> r.beløp().compareTo(BigDecimal.ZERO) == 0)
+            .map(r -> r.fom().minusDays(1));
+    }
+
+    private static List<RefusjonsendringEntitet> mapRefusjonsendringer(LocalDate startdato,
+                                                                        LocalDate opphørsdato,
+                                                                        List<RefusjonDto> refusjon) {
+        // Opphør og start ligger på egne felter, så disse skal ikke mappes som endringer.
+        // Merk at opphørsdato er dagen før endring som opphører refusjon, derfor må vi legge til en dag.
+        return refusjon.stream()
+            .filter(r -> !r.fom().equals(startdato))
+            .filter(r -> opphørsdato == null || !r.fom().equals(opphørsdato.plusDays(1)))
+            .map(r -> new RefusjonsendringEntitet(r.fom(), r.beløp()))
+            .toList();
+    }
+
+    private static List<BortaltNaturalytelseEntitet> mapBortfalteNaturalytelser(List<BortfaltNaturalytelseDto> dto) {
+        return dto.stream()
+            .map(d -> BortaltNaturalytelseEntitet.builder()
+                .medPeriode(d.fom(), d.tom() != null ? d.tom() : Tid.TIDENES_ENDE)
+                .medMånedBeløp(d.beløp())
+                .medType(NaturalytelseType.valueOf(d.naturalytelsetype().name()))
+                .build())
+            .toList();
+    }
+
+    private static List<EndringsårsakEntitet> mapEndringsårsaker(List<EndringsårsakerDto> endringsårsaker) {
+        return endringsårsaker.stream()
+            .map(endringsårsak -> EndringsårsakEntitet.builder()
+                .medÅrsak(Endringsårsak.valueOf(endringsårsak.årsak().name()))
+                .medFom(endringsårsak.fom())
+                .medTom(endringsårsak.tom())
+                .medBleKjentFra(endringsårsak.bleKjentFom())
+                .build())
+            .toList();
+    }
+
+    private static List<RefusjonDto> mapRefusjonsendringerTilKontrakt(InntektsmeldingEntitet entitet) {
+        List<RefusjonDto> refusjoner = new ArrayList<>();
+        if (entitet.getMånedRefusjon() != null) {
+            refusjoner.add(new RefusjonDto(entitet.getStartDato(), entitet.getMånedRefusjon()));
+        }
+        if (entitet.getOpphørsdatoRefusjon() != null && !Tid.TIDENES_ENDE.equals(entitet.getOpphørsdatoRefusjon())) {
+            refusjoner.add(new RefusjonDto(entitet.getOpphørsdatoRefusjon().plusDays(1), BigDecimal.ZERO));
+        }
+        entitet.getRefusjonsendringer().stream()
+            .map(r -> new RefusjonDto(r.getFom(), r.getRefusjonPrMnd()))
+            .forEach(refusjoner::add);
+        return refusjoner.stream().sorted(Comparator.comparing(RefusjonDto::fom)).toList();
+    }
+
+    private static List<BortfaltNaturalytelseDto> mapBortfalteNaturalytelserTilKontrakt(List<BortaltNaturalytelseEntitet> bortfalte) {
+        return bortfalte.stream()
+            .map(b -> new BortfaltNaturalytelseDto(
+                b.getPeriode().getFom(),
+                Tid.TIDENES_ENDE.equals(b.getPeriode().getTom()) ? null : b.getPeriode().getTom(),
+                NaturalytelsetypeDto.valueOf(b.getType().name()),
+                b.getMånedBeløp()))
+            .toList();
+    }
+
+    private static List<EndringsårsakerDto> mapEndringsårsakerTilKontrakt(List<EndringsårsakEntitet> endringsårsaker) {
+        return endringsårsaker.stream()
+            .map(e -> new EndringsårsakerDto(
+                no.nav.k9.inntektsmelding.felles.EndringsårsakDto.valueOf(e.getÅrsak().name()),
+                e.getFom().orElse(null),
+                e.getTom().orElse(null),
+                e.getBleKjentFom().orElse(null)))
+            .toList();
+    }
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMapper.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMapper.java
@@ -110,7 +110,7 @@ class InntektsmeldingApiMapper {
         return new AvsenderSystemDto("NAV_NO", "1.0");
     }
 
-    private static Ytelsetype mapYtelsetype(YtelseTypeDto ytelseTypeDto) {
+    static Ytelsetype mapYtelsetype(YtelseTypeDto ytelseTypeDto) {
         return switch (ytelseTypeDto) {
             case OMSORGSPENGER -> Ytelsetype.OMSORGSPENGER;
             case OPPLÆRINGSPENGER -> Ytelsetype.OPPLÆRINGSPENGER;

--- a/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMapper.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMapper.java
@@ -71,7 +71,10 @@ class InntektsmeldingApiMapper {
 
     static InntektsmeldingDto mapFraEntitet(InntektsmeldingEntitet inntektsmelding, PersonIdent personIdent) {
         var forespørsel = inntektsmelding.getForespørsel();
-        return new InntektsmeldingDto(
+        if (personIdent == null) {
+            throw new IllegalArgumentException("Finner ikke fødselsnummer for aktørId når personIdent er null." );
+        }
+            return new InntektsmeldingDto(
             inntektsmelding.getUuid(),
             forespørsel.getUuid(),
             new FødselsnummerDto(personIdent.getIdent()),

--- a/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMottakTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMottakTjeneste.java
@@ -84,12 +84,12 @@ public class InntektsmeldingApiMottakTjeneste {
                     sisteIm.getUuid().toString()));
         }
 
-        var inntektSjekk = sjekkMånedInntektMotRapportertInntekt(request, aktørId, forespørsel, nyIm);
+        SendInntektsmeldingResponse inntektSjekk = sjekkMånedInntektMotRapportertInntekt(request, aktørId, forespørsel, nyIm);
         if (!inntektSjekk.success()) {
             return inntektSjekk;
         }
 
-        var imId = lagreOgLagJournalførTask(nyIm, forespørsel);
+        Long imId = lagreOgLagJournalførTask(nyIm, forespørsel);
 
         forespørselBehandlingTjeneste.ferdigstillForespørsel(
             request.foresporselUuid(),
@@ -99,7 +99,7 @@ public class InntektsmeldingApiMottakTjeneste {
             Optional.of(nyIm.getUuid())
         );
 
-        var lagretEntitet = inntektsmeldingRepository.hentInntektsmelding(imId);
+        InntektsmeldingEntitet lagretEntitet = inntektsmeldingRepository.hentInntektsmelding(imId);
         MetrikkerTjeneste.loggInnsendtInntektsmelding(lagretEntitet);
 
         return new SendInntektsmeldingResponse(true, lagretEntitet.getUuid(), null);
@@ -117,7 +117,7 @@ public class InntektsmeldingApiMottakTjeneste {
             forespørsel.getYtelseType()
         );
 
-        var nedetidAInntekt = inntektFraAInntekt.måneder() != null && inntektFraAInntekt.måneder().stream()
+        boolean nedetidAInntekt = inntektFraAInntekt.måneder() != null && inntektFraAInntekt.måneder().stream()
             .anyMatch(m -> MånedslønnStatus.NEDETID_AINNTEKT.equals(m.status()));
 
         if (nedetidAInntekt) {
@@ -128,12 +128,12 @@ public class InntektsmeldingApiMottakTjeneste {
                     request.foresporselUuid().toString()));
         }
 
-        var inntektErUlikOgIngenÅrsakOppgitt = inntektFraAInntekt.gjennomsnitt() != null
+        boolean inntektErUlikOgIngenÅrsakOppgitt = inntektFraAInntekt.gjennomsnitt() != null
             && inntektFraAInntekt.gjennomsnitt().subtract(entitet.getMånedInntekt()).abs().compareTo(AKSEPTERT_AVVIK) > 0
             && (entitet.getEndringsårsaker() == null || entitet.getEndringsårsaker().isEmpty());
 
         if (inntektErUlikOgIngenÅrsakOppgitt) {
-            var feilmelding = String.format(
+            String feilmelding = String.format(
                 "Inntekt i inntektsmelding er ulik inntekt fra A-inntekt, og ingen endringsårsak er oppgitt. Gjennomsnittlig inntekt fra A-inntekt: %s, oppgitt inntekt: %s",
                 inntektFraAInntekt.gjennomsnitt(), entitet.getMånedInntekt());
             return new SendInntektsmeldingResponse(false, null,
@@ -154,13 +154,13 @@ public class InntektsmeldingApiMottakTjeneste {
 
     private Long lagreOgLagJournalførTask(InntektsmeldingEntitet inntektsmelding, ForespørselEntitet forespørsel) {
         LOG.info("Lagrer inntektsmelding fra LPS-system for ytelse {} og saksnummer {}", inntektsmelding.getYtelsetype(), forespørsel.getSaksnummer().orElse(null));
-        var imId = inntektsmeldingRepository.lagreInntektsmelding(inntektsmelding);
+        Long imId = inntektsmeldingRepository.lagreInntektsmelding(inntektsmelding);
         opprettTaskForSendTilJoark(inntektsmelding, forespørsel, imId);
         return imId;
     }
 
     private void opprettTaskForSendTilJoark(InntektsmeldingEntitet inntektsmelding, ForespørselEntitet forespørsel, Long imId) {
-        var task = ProsessTaskData.forProsessTask(SendTilJoarkTask.class);
+        ProsessTaskData task = ProsessTaskData.forProsessTask(SendTilJoarkTask.class);
         forespørsel.getSaksnummer().ifPresent(task::setSaksnummer);
         task.setProperty(SendTilJoarkTask.KEY_INNTEKTSMELDING_ID, imId.toString());
         task.setProperty(SendTilJoarkTask.KEY_YTELSE_TYPE, inntektsmelding.getYtelsetype().toString());

--- a/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMottakTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMottakTjeneste.java
@@ -154,6 +154,8 @@ public class InntektsmeldingApiMottakTjeneste {
             && Objects.equals(ny.getKontaktperson().getNavn(), gammel.getKontaktperson().getNavn())
             && Objects.equals(ny.getKontaktperson().getTelefonnummer(), gammel.getKontaktperson().getTelefonnummer())
             && new HashSet<>(ny.getBorfalteNaturalYtelser()).equals(new HashSet<>(gammel.getBorfalteNaturalYtelser()))
+            && new HashSet<>(ny.getRefusjonsendringer()).equals(new HashSet<>(gammel.getRefusjonsendringer()))
+            && new HashSet<>(ny.getEndringsårsaker()).equals(new HashSet<>(gammel.getEndringsårsaker()))
             && Objects.equals(ny.getOmsorgspenger(), gammel.getOmsorgspenger());
     }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMottakTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMottakTjeneste.java
@@ -2,6 +2,7 @@ package no.nav.familie.inntektsmelding.imapi.inntektsmelding;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -151,7 +152,9 @@ public class InntektsmeldingApiMottakTjeneste {
             && Objects.equals(ny.getMånedRefusjon(), gammel.getMånedRefusjon())
             && Objects.equals(ny.getOpphørsdatoRefusjon(), gammel.getOpphørsdatoRefusjon())
             && Objects.equals(ny.getKontaktperson().getNavn(), gammel.getKontaktperson().getNavn())
-            && Objects.equals(ny.getKontaktperson().getTelefonnummer(), gammel.getKontaktperson().getTelefonnummer());
+            && Objects.equals(ny.getKontaktperson().getTelefonnummer(), gammel.getKontaktperson().getTelefonnummer())
+            && new HashSet<>(ny.getBorfalteNaturalYtelser()).equals(new HashSet<>(gammel.getBorfalteNaturalYtelser()))
+            && Objects.equals(ny.getOmsorgspenger(), gammel.getOmsorgspenger());
     }
 
     private Long lagreOgLagJournalførTask(InntektsmeldingEntitet inntektsmelding, ForespørselEntitet forespørsel) {

--- a/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMottakTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMottakTjeneste.java
@@ -75,7 +75,9 @@ public class InntektsmeldingApiMottakTjeneste {
 
         InntektsmeldingEntitet nyIm = InntektsmeldingApiMapper.mapTilEntitet(request, aktørId, forespørsel);
 
-        InntektsmeldingEntitet sisteIm = forespørsel.getInntektsmeldinger().stream().findFirst().orElse(null);
+        InntektsmeldingEntitet sisteIm = forespørsel.getInntektsmeldinger().stream()
+            .max(java.util.Comparator.comparing(InntektsmeldingEntitet::getOpprettetTidspunkt))
+            .orElse(null);
         if (sisteIm != null && inntektsmeldingerErLike(nyIm, sisteIm)) {
             LOG.info("Inntektsmelding avvises. Ingen endring sammenlignet med sist innsendt. forespørselUuid: {}", request.foresporselUuid());
             return new SendInntektsmeldingResponse(false, null,

--- a/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMottakTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMottakTjeneste.java
@@ -1,0 +1,169 @@
+package no.nav.familie.inntektsmelding.imapi.inntektsmelding;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Objects;
+import java.util.Optional;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.LukkeÅrsak;
+import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingRepository;
+import no.nav.familie.inntektsmelding.imdialog.task.SendTilJoarkTask;
+import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.InntektTjeneste;
+import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.Inntektsopplysninger;
+import no.nav.familie.inntektsmelding.koder.ForespørselStatus;
+import no.nav.familie.inntektsmelding.metrikker.MetrikkerTjeneste;
+import no.nav.familie.inntektsmelding.typer.dto.MånedslønnStatus;
+import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
+import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
+import no.nav.k9.inntektsmelding.felles.FeilkodeDto;
+import no.nav.k9.inntektsmelding.imapi.inntektsmelding.SendInntektsmeldingRequest;
+import no.nav.k9.inntektsmelding.imapi.inntektsmelding.SendInntektsmeldingResponse;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
+
+@ApplicationScoped
+public class InntektsmeldingApiMottakTjeneste {
+    private static final Logger LOG = LoggerFactory.getLogger(InntektsmeldingApiMottakTjeneste.class);
+    private static final BigDecimal AKSEPTERT_AVVIK = new BigDecimal("50");
+
+    private ForespørselBehandlingTjeneste forespørselBehandlingTjeneste;
+    private InntektsmeldingRepository inntektsmeldingRepository;
+    private ProsessTaskTjeneste prosessTaskTjeneste;
+    private InntektTjeneste inntektTjeneste;
+
+    InntektsmeldingApiMottakTjeneste() {
+        // CDI
+    }
+
+    @Inject
+    public InntektsmeldingApiMottakTjeneste(ForespørselBehandlingTjeneste forespørselBehandlingTjeneste,
+                                            InntektsmeldingRepository inntektsmeldingRepository,
+                                            ProsessTaskTjeneste prosessTaskTjeneste,
+                                            InntektTjeneste inntektTjeneste) {
+        this.forespørselBehandlingTjeneste = forespørselBehandlingTjeneste;
+        this.inntektsmeldingRepository = inntektsmeldingRepository;
+        this.prosessTaskTjeneste = prosessTaskTjeneste;
+        this.inntektTjeneste = inntektTjeneste;
+    }
+
+    public SendInntektsmeldingResponse mottaInntektsmelding(SendInntektsmeldingRequest request, AktørIdEntitet aktørId) {
+        ForespørselEntitet forespørsel = forespørselBehandlingTjeneste.hentForespørsel(request.foresporselUuid()).orElse(null);
+        if (forespørsel == null) {
+            LOG.info("Finner ikke forespørsel for uuid {}", request.foresporselUuid());
+            return new SendInntektsmeldingResponse(false, null,
+                new SendInntektsmeldingResponse.FeilInfo(FeilkodeDto.TOM_FORESPOERSEL,
+                    "Finner ikke forespørsel for uuid " + request.foresporselUuid(),
+                    request.foresporselUuid().toString()));
+        }
+
+        if (ForespørselStatus.UTGÅTT.equals(forespørsel.getStatus())) {
+            LOG.info("Forespørsel har status utgått, kan ikke motta inntektsmelding. forespørselUuid: {}", request.foresporselUuid());
+            return new SendInntektsmeldingResponse(false, null,
+                new SendInntektsmeldingResponse.FeilInfo(FeilkodeDto.UGYLDIG_FORESPOERSEL,
+                    "Det er ikke tillatt å sende inn en inntektsmelding på en forkastet forespørsel",
+                    request.foresporselUuid().toString()));
+        }
+
+        InntektsmeldingEntitet nyIm = InntektsmeldingApiMapper.mapTilEntitet(request, aktørId, forespørsel);
+
+        InntektsmeldingEntitet sisteIm = forespørsel.getInntektsmeldinger().stream().findFirst().orElse(null);
+        if (sisteIm != null && inntektsmeldingerErLike(nyIm, sisteIm)) {
+            LOG.info("Inntektsmelding avvises. Ingen endring sammenlignet med sist innsendt. forespørselUuid: {}", request.foresporselUuid());
+            return new SendInntektsmeldingResponse(false, null,
+                new SendInntektsmeldingResponse.FeilInfo(FeilkodeDto.DUPLIKAT,
+                    "Inntektsmelding avvises. Ingen endring sammenlignet med sist innsendt inntektsmelding med uuid: " + sisteIm.getUuid(),
+                    sisteIm.getUuid().toString()));
+        }
+
+        var inntektSjekk = sjekkMånedInntektMotRapportertInntekt(request, aktørId, forespørsel, nyIm);
+        if (!inntektSjekk.success()) {
+            return inntektSjekk;
+        }
+
+        var imId = lagreOgLagJournalførTask(nyIm, forespørsel);
+
+        forespørselBehandlingTjeneste.ferdigstillForespørsel(
+            request.foresporselUuid(),
+            aktørId,
+            new OrganisasjonsnummerDto(request.organisasjonsnummer().orgnr()),
+            LukkeÅrsak.ORDINÆR_INNSENDING,
+            Optional.of(nyIm.getUuid())
+        );
+
+        var lagretEntitet = inntektsmeldingRepository.hentInntektsmelding(imId);
+        MetrikkerTjeneste.loggInnsendtInntektsmelding(lagretEntitet);
+
+        return new SendInntektsmeldingResponse(true, lagretEntitet.getUuid(), null);
+    }
+
+    private SendInntektsmeldingResponse sjekkMånedInntektMotRapportertInntekt(SendInntektsmeldingRequest request,
+                                                                               AktørIdEntitet aktørId,
+                                                                               ForespørselEntitet forespørsel,
+                                                                               InntektsmeldingEntitet entitet) {
+        Inntektsopplysninger inntektFraAInntekt = inntektTjeneste.hentInntekt(
+            aktørId,
+            forespørsel.getSkjæringstidspunkt(),
+            LocalDate.now(),
+            request.organisasjonsnummer().orgnr(),
+            forespørsel.getYtelseType()
+        );
+
+        var nedetidAInntekt = inntektFraAInntekt.måneder() != null && inntektFraAInntekt.måneder().stream()
+            .anyMatch(m -> MånedslønnStatus.NEDETID_AINNTEKT.equals(m.status()));
+
+        if (nedetidAInntekt) {
+            LOG.warn("Inntektskomponenten har nedetid. forespørselUuid: {}", request.foresporselUuid());
+            return new SendInntektsmeldingResponse(false, null,
+                new SendInntektsmeldingResponse.FeilInfo(FeilkodeDto.NEDETID_AINNTEKT,
+                    "Inntektskomponenten har nedetid, og vi kan ikke verifisere inntekt. Prøv igjen om litt.",
+                    request.foresporselUuid().toString()));
+        }
+
+        var inntektErUlikOgIngenÅrsakOppgitt = inntektFraAInntekt.gjennomsnitt() != null
+            && inntektFraAInntekt.gjennomsnitt().subtract(entitet.getMånedInntekt()).abs().compareTo(AKSEPTERT_AVVIK) > 0
+            && (entitet.getEndringsårsaker() == null || entitet.getEndringsårsaker().isEmpty());
+
+        if (inntektErUlikOgIngenÅrsakOppgitt) {
+            var feilmelding = String.format(
+                "Inntekt i inntektsmelding er ulik inntekt fra A-inntekt, og ingen endringsårsak er oppgitt. Gjennomsnittlig inntekt fra A-inntekt: %s, oppgitt inntekt: %s",
+                inntektFraAInntekt.gjennomsnitt(), entitet.getMånedInntekt());
+            return new SendInntektsmeldingResponse(false, null,
+                new SendInntektsmeldingResponse.FeilInfo(FeilkodeDto.ULIK_INNTEKT, feilmelding, request.foresporselUuid().toString()));
+        }
+
+        return new SendInntektsmeldingResponse(true, null, null);
+    }
+
+    private boolean inntektsmeldingerErLike(InntektsmeldingEntitet ny, InntektsmeldingEntitet gammel) {
+        return Objects.equals(ny.getStartDato(), gammel.getStartDato())
+            && Objects.equals(ny.getMånedInntekt(), gammel.getMånedInntekt())
+            && Objects.equals(ny.getMånedRefusjon(), gammel.getMånedRefusjon())
+            && Objects.equals(ny.getOpphørsdatoRefusjon(), gammel.getOpphørsdatoRefusjon())
+            && Objects.equals(ny.getKontaktperson().getNavn(), gammel.getKontaktperson().getNavn())
+            && Objects.equals(ny.getKontaktperson().getTelefonnummer(), gammel.getKontaktperson().getTelefonnummer());
+    }
+
+    private Long lagreOgLagJournalførTask(InntektsmeldingEntitet inntektsmelding, ForespørselEntitet forespørsel) {
+        LOG.info("Lagrer inntektsmelding fra LPS-system for ytelse {} og saksnummer {}", inntektsmelding.getYtelsetype(), forespørsel.getSaksnummer().orElse(null));
+        var imId = inntektsmeldingRepository.lagreInntektsmelding(inntektsmelding);
+        opprettTaskForSendTilJoark(inntektsmelding, forespørsel, imId);
+        return imId;
+    }
+
+    private void opprettTaskForSendTilJoark(InntektsmeldingEntitet inntektsmelding, ForespørselEntitet forespørsel, Long imId) {
+        var task = ProsessTaskData.forProsessTask(SendTilJoarkTask.class);
+        forespørsel.getSaksnummer().ifPresent(task::setSaksnummer);
+        task.setProperty(SendTilJoarkTask.KEY_INNTEKTSMELDING_ID, imId.toString());
+        task.setProperty(SendTilJoarkTask.KEY_YTELSE_TYPE, inntektsmelding.getYtelsetype().toString());
+        prosessTaskTjeneste.lagre(task);
+    }
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiRest.java
@@ -1,0 +1,106 @@
+package no.nav.familie.inntektsmelding.imapi.inntektsmelding;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
+import no.nav.familie.inntektsmelding.server.auth.api.AutentisertMedAzure;
+import no.nav.familie.inntektsmelding.server.auth.api.Tilgangskontrollert;
+import no.nav.familie.inntektsmelding.server.tilgangsstyring.Tilgang;
+import no.nav.k9.inntektsmelding.felles.FeilkodeDto;
+import no.nav.k9.inntektsmelding.imapi.inntektsmelding.HentInntektsmeldingerRequest;
+import no.nav.k9.inntektsmelding.imapi.inntektsmelding.HentInntektsmeldingerResponse;
+import no.nav.k9.inntektsmelding.imapi.inntektsmelding.InntektsmeldingDto;
+import no.nav.k9.inntektsmelding.imapi.inntektsmelding.SendInntektsmeldingRequest;
+import no.nav.k9.inntektsmelding.imapi.inntektsmelding.SendInntektsmeldingResponse;
+
+@AutentisertMedAzure
+@ApplicationScoped
+@Transactional
+@Path(InntektsmeldingApiRest.BASE_PATH)
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class InntektsmeldingApiRest {
+    public static final String BASE_PATH = "/imapi/inntektsmelding";
+    private static final Logger LOG = LoggerFactory.getLogger(InntektsmeldingApiRest.class);
+
+    private InntektsmeldingApiTjeneste inntektsmeldingApiTjeneste;
+    private InntektsmeldingApiMottakTjeneste mottakTjeneste;
+    private PersonTjeneste personTjeneste;
+    private Tilgang tilgang;
+
+    InntektsmeldingApiRest() {
+        // CDI
+    }
+
+    @Inject
+    public InntektsmeldingApiRest(InntektsmeldingApiTjeneste inntektsmeldingApiTjeneste,
+                                  InntektsmeldingApiMottakTjeneste mottakTjeneste,
+                                  PersonTjeneste personTjeneste,
+                                  Tilgang tilgang) {
+        this.inntektsmeldingApiTjeneste = inntektsmeldingApiTjeneste;
+        this.mottakTjeneste = mottakTjeneste;
+        this.personTjeneste = personTjeneste;
+        this.tilgang = tilgang;
+    }
+
+    @GET
+    @Path("/hent/{inntektsmeldingUuid}")
+    @Tilgangskontrollert
+    public Response hentInntektsmelding(@NotNull @Valid @PathParam("inntektsmeldingUuid") UUID inntektsmeldingUuid) {
+        sjekkErSystemkall();
+        Optional<InntektsmeldingDto> im = inntektsmeldingApiTjeneste.hentInntektsmelding(inntektsmeldingUuid);
+        if (im.isEmpty()) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        return Response.ok(im.get()).build();
+    }
+
+    @POST
+    @Path("/hent/inntektsmeldinger")
+    @Tilgangskontrollert
+    public Response hentInntektsmeldinger(@NotNull @Valid HentInntektsmeldingerRequest request) {
+        sjekkErSystemkall();
+        List<InntektsmeldingDto> inntektsmeldinger = inntektsmeldingApiTjeneste.hentInntektsmeldinger(request);
+        return Response.ok(new HentInntektsmeldingerResponse(inntektsmeldinger)).build();
+    }
+
+    @POST
+    @Path("/send-inntektsmelding")
+    @Tilgangskontrollert
+    public SendInntektsmeldingResponse sendInntektsmelding(@NotNull @Valid SendInntektsmeldingRequest request) {
+        sjekkErSystemkall();
+        var aktørId = personTjeneste.finnAktørIdForPersonIdent(request.fødselsnummer().fnr());
+
+        if (aktørId.isEmpty()) {
+            LOG.error("Finner ikke aktørId for fødselsnummer.");
+            return new SendInntektsmeldingResponse(false, null,
+                new SendInntektsmeldingResponse.FeilInfo(FeilkodeDto.INGEN_AKTØR_ID,
+                    "Finner ikke informasjon for fødselsnummer. Sjekk at fødselsnummer er korrekt",
+                    request.foresporselUuid().toString()));
+        }
+        return mottakTjeneste.mottaInntektsmelding(request, aktørId.get());
+    }
+
+    private void sjekkErSystemkall() {
+        tilgang.sjekkErSystembruker();
+    }
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiTjeneste.java
@@ -1,5 +1,7 @@
 package no.nav.familie.inntektsmelding.imapi.inntektsmelding;
 
+import static no.nav.familie.inntektsmelding.imapi.inntektsmelding.InntektsmeldingApiMapper.mapYtelsetype;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -82,14 +84,5 @@ public class InntektsmeldingApiTjeneste {
         return inntektsmeldinger.stream()
             .map(im -> InntektsmeldingApiMapper.mapFraEntitet(im, aktørIdPersonIdentMap.get(im.getAktørId())))
             .toList();
-    }
-
-    private static Ytelsetype mapYtelsetype(no.nav.k9.inntektsmelding.felles.YtelseTypeDto dto) {
-        return switch (dto) {
-            case OMSORGSPENGER -> Ytelsetype.OMSORGSPENGER;
-            case OPPLÆRINGSPENGER -> Ytelsetype.OPPLÆRINGSPENGER;
-            case PLEIEPENGER_SYKT_BARN -> Ytelsetype.PLEIEPENGER_SYKT_BARN;
-            case PLEIEPENGER_I_LIVETS_SLUTTFASE -> Ytelsetype.PLEIEPENGER_NÆRSTÅENDE;
-        };
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiTjeneste.java
@@ -12,6 +12,9 @@ import java.util.stream.Collectors;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
 import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
 import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingEntitet;
@@ -25,6 +28,7 @@ import no.nav.k9.inntektsmelding.imapi.inntektsmelding.InntektsmeldingDto;
 
 @ApplicationScoped
 public class InntektsmeldingApiTjeneste {
+    private static final Logger LOG = LoggerFactory.getLogger(InntektsmeldingApiTjeneste.class);
 
     private InntektsmeldingRepository inntektsmeldingRepository;
     private ForespørselBehandlingTjeneste forespørselBehandlingTjeneste;
@@ -71,9 +75,15 @@ public class InntektsmeldingApiTjeneste {
     }
 
     private List<InntektsmeldingDto> hentInntektsmeldingerFraFilter(HentInntektsmeldingerRequest request) {
-        AktørIdEntitet aktørId = request.fnr() != null
-            ? personTjeneste.finnAktørIdForPersonIdent(request.fnr().fnr()).orElse(null)
-            : null;
+        AktørIdEntitet aktørId = null;
+        if (request.fnr() != null) {
+            aktørId = personTjeneste.finnAktørIdForPersonIdent(request.fnr().fnr()).orElse(null);
+            if (aktørId == null) {
+                LOG.warn("Finner ikke aktørId ved henting av inntektsmelding fra filter, returnerer tom liste");
+                return List.of();
+            }
+        }
+
         Ytelsetype ytelsetype = request.ytelseType() != null ? mapYtelsetype(request.ytelseType()) : null;
         List<InntektsmeldingEntitet> inntektsmeldinger = inntektsmeldingRepository.hentInntektsmeldingerFraFilter(
             request.orgnr().orgnr(), aktørId, ytelsetype, request.fom(), request.tom());
@@ -82,7 +92,13 @@ public class InntektsmeldingApiTjeneste {
         Map<AktørIdEntitet, PersonIdent> aktørIdPersonIdentMap = personTjeneste.finnPersonIdentForAktørIdBolk(aktørIder);
 
         return inntektsmeldinger.stream()
-            .map(im -> InntektsmeldingApiMapper.mapFraEntitet(im, aktørIdPersonIdentMap.get(im.getAktørId())))
+            .map(im -> {
+                var personIdent = aktørIdPersonIdentMap.get(im.getAktørId());
+                if (personIdent == null) {
+                    throw new IllegalArgumentException("Finner ikke fødselsnummer for aktørId.");
+                }
+                return InntektsmeldingApiMapper.mapFraEntitet(im, personIdent);
+            })
             .toList();
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiTjeneste.java
@@ -1,0 +1,95 @@
+package no.nav.familie.inntektsmelding.imapi.inntektsmelding;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
+import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingRepository;
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
+import no.nav.k9.inntektsmelding.imapi.inntektsmelding.HentInntektsmeldingerRequest;
+import no.nav.k9.inntektsmelding.imapi.inntektsmelding.InntektsmeldingDto;
+
+@ApplicationScoped
+public class InntektsmeldingApiTjeneste {
+
+    private InntektsmeldingRepository inntektsmeldingRepository;
+    private ForespørselBehandlingTjeneste forespørselBehandlingTjeneste;
+    private PersonTjeneste personTjeneste;
+
+    InntektsmeldingApiTjeneste() {
+        // CDI
+    }
+
+    @Inject
+    public InntektsmeldingApiTjeneste(InntektsmeldingRepository inntektsmeldingRepository,
+                                      ForespørselBehandlingTjeneste forespørselBehandlingTjeneste,
+                                      PersonTjeneste personTjeneste) {
+        this.inntektsmeldingRepository = inntektsmeldingRepository;
+        this.forespørselBehandlingTjeneste = forespørselBehandlingTjeneste;
+        this.personTjeneste = personTjeneste;
+    }
+
+    public Optional<InntektsmeldingDto> hentInntektsmelding(UUID inntektsmeldingUuid) {
+        return inntektsmeldingRepository.hentInntektsmeldingForUuid(inntektsmeldingUuid)
+            .map(entitet -> {
+                var personIdent = personTjeneste.finnPersonIdentForAktørId(entitet.getAktørId());
+                return InntektsmeldingApiMapper.mapFraEntitet(entitet, personIdent);
+            });
+    }
+
+    public List<InntektsmeldingDto> hentInntektsmeldinger(HentInntektsmeldingerRequest request) {
+        if (request.forespørselUuid() != null) {
+            return hentInntektsmeldingerForForespørsel(request.forespørselUuid());
+        }
+        return hentInntektsmeldingerFraFilter(request);
+    }
+
+    private List<InntektsmeldingDto> hentInntektsmeldingerForForespørsel(UUID forespørselUuid) {
+        return forespørselBehandlingTjeneste.hentForespørsel(forespørselUuid)
+            .map(ForespørselEntitet::getInntektsmeldinger)
+            .orElse(List.of())
+            .stream()
+            .map(inntektsmelding -> {
+                var personIdent = personTjeneste.finnPersonIdentForAktørId(inntektsmelding.getAktørId());
+                return InntektsmeldingApiMapper.mapFraEntitet(inntektsmelding, personIdent);
+            })
+            .toList();
+    }
+
+    private List<InntektsmeldingDto> hentInntektsmeldingerFraFilter(HentInntektsmeldingerRequest request) {
+        AktørIdEntitet aktørId = request.fnr() != null
+            ? personTjeneste.finnAktørIdForPersonIdent(request.fnr().fnr()).orElse(null)
+            : null;
+        Ytelsetype ytelsetype = request.ytelseType() != null ? mapYtelsetype(request.ytelseType()) : null;
+        List<InntektsmeldingEntitet> inntektsmeldinger = inntektsmeldingRepository.hentInntektsmeldingerFraFilter(
+            request.orgnr().orgnr(), aktørId, ytelsetype, request.fom(), request.tom());
+
+        Set<AktørIdEntitet> aktørIder = inntektsmeldinger.stream().map(im -> im.getAktørId()).collect(Collectors.toSet());
+        Map<AktørIdEntitet, PersonIdent> aktørIdPersonIdentMap = personTjeneste.finnPersonIdentForAktørIdBolk(aktørIder);
+
+        return inntektsmeldinger.stream()
+            .map(im -> InntektsmeldingApiMapper.mapFraEntitet(im, aktørIdPersonIdentMap.get(im.getAktørId())))
+            .toList();
+    }
+
+    private static Ytelsetype mapYtelsetype(no.nav.k9.inntektsmelding.felles.YtelseTypeDto dto) {
+        return switch (dto) {
+            case OMSORGSPENGER -> Ytelsetype.OMSORGSPENGER;
+            case OPPLÆRINGSPENGER -> Ytelsetype.OPPLÆRINGSPENGER;
+            case PLEIEPENGER_SYKT_BARN -> Ytelsetype.PLEIEPENGER_SYKT_BARN;
+            case PLEIEPENGER_I_LIVETS_SLUTTFASE -> Ytelsetype.PLEIEPENGER_NÆRSTÅENDE;
+        };
+    }
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/BortaltNaturalytelseEntitet.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/BortaltNaturalytelseEntitet.java
@@ -2,6 +2,7 @@ package no.nav.familie.inntektsmelding.imdialog.modell;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Objects;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -62,6 +63,20 @@ public class BortaltNaturalytelseEntitet {
     @Override
     public String toString() {
         return "BortfaltNaturalytelseEntitet{" + "periode=" + periode + ", type=" + type + ", beløp=" + månedBeløp + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof BortaltNaturalytelseEntitet that)) return false;
+        return Objects.equals(periode, that.periode)
+            && type == that.type
+            && (månedBeløp == null ? that.månedBeløp == null : månedBeløp.compareTo(that.månedBeløp) == 0);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(periode, type, månedBeløp == null ? null : månedBeløp.stripTrailingZeros());
     }
 
     public static Builder builder() {

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/DelvisFraværsPeriodeEntitet.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/DelvisFraværsPeriodeEntitet.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Table;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Objects;
 
 @Entity(name = "DelvisFraværsPeriodeEntitet")
 @Table(name = "DELVIS_FRAVAERS_PERIODE")
@@ -57,6 +58,19 @@ public class DelvisFraværsPeriodeEntitet {
             "dato=" + dato +
             ", timer=" + timer +
             '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DelvisFraværsPeriodeEntitet that)) return false;
+        return Objects.equals(dato, that.dato)
+            && (timer == null ? that.timer == null : timer.compareTo(that.timer) == 0);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dato, timer == null ? null : timer.stripTrailingZeros());
     }
 
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/EndringsårsakEntitet.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/EndringsårsakEntitet.java
@@ -76,6 +76,21 @@ public class EndringsårsakEntitet {
             '}';
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof EndringsårsakEntitet that)) return false;
+        return årsak == that.årsak
+            && Objects.equals(fom, that.fom)
+            && Objects.equals(tom, that.tom)
+            && Objects.equals(bleKjentFom, that.bleKjentFom);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(årsak, fom, tom, bleKjentFom);
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/FraværsPeriodeEntitet.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/FraværsPeriodeEntitet.java
@@ -9,6 +9,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
+import java.util.Objects;
+
 @Entity(name = "FraværsPeriodeEntitet")
 @Table(name = "FRAVAERS_PERIODE")
 public class FraværsPeriodeEntitet {
@@ -49,6 +51,18 @@ public class FraværsPeriodeEntitet {
         return "FraværsPeriodeEntitet{" +
             "periode=" + periode +
             '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof FraværsPeriodeEntitet that)) return false;
+        return Objects.equals(periode, that.periode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(periode);
     }
 
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/InntektsmeldingEntitet.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/InntektsmeldingEntitet.java
@@ -95,6 +95,9 @@ public class InntektsmeldingEntitet {
     @OneToOne(cascade = CascadeType.ALL, mappedBy = "inntektsmelding")
     private OmsorgspengerEntitet omsorgspenger;
 
+    @OneToOne(cascade = CascadeType.ALL, mappedBy = "inntektsmelding")
+    private LpsSystemInfoEntitet lpsSystem;
+
     @ManyToOne()
     @JoinColumn(name = "foresporsel_id", nullable = false, updatable = false)
     private ForespørselEntitet forespørsel;
@@ -177,6 +180,10 @@ public class InntektsmeldingEntitet {
 
     public ForespørselEntitet getForespørsel() {
         return forespørsel;
+    }
+
+    public LpsSystemInfoEntitet getLpsSystem() {
+        return lpsSystem;
     }
 
     private void leggTilRefusjonsendring(RefusjonsendringEntitet refusjonsendringEntitet) {
@@ -341,6 +348,12 @@ public class InntektsmeldingEntitet {
         public Builder medOmsorgspenger(OmsorgspengerEntitet omsorgspenger) {
             omsorgspenger.setInntektsmelding(kladd);
             kladd.omsorgspenger = omsorgspenger;
+            return this;
+        }
+
+        public Builder medLpsSystemInfo(LpsSystemInfoEntitet lpsSystem) {
+            lpsSystem.setInntektsmelding(kladd);
+            kladd.lpsSystem = lpsSystem;
             return this;
         }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/InntektsmeldingRepository.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/InntektsmeldingRepository.java
@@ -1,6 +1,9 @@
 package no.nav.familie.inntektsmelding.imdialog.modell;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
@@ -33,6 +36,51 @@ public class InntektsmeldingRepository {
 
     public InntektsmeldingEntitet hentInntektsmelding(long inntektsmeldingId) {
         return entityManager.find(InntektsmeldingEntitet.class, inntektsmeldingId);
+    }
+
+    public Optional<InntektsmeldingEntitet> hentInntektsmeldingForUuid(UUID uuid) {
+        var query = entityManager.createQuery(
+                "FROM InntektsmeldingEntitet where uuid = :uuid",
+                InntektsmeldingEntitet.class)
+            .setParameter("uuid", uuid);
+        return query.getResultStream().findFirst();
+    }
+
+    public List<InntektsmeldingEntitet> hentInntektsmeldingerFraFilter(String orgnr,
+                                                                       AktørIdEntitet aktørId,
+                                                                       Ytelsetype ytelsetype,
+                                                                       LocalDate fom,
+                                                                       LocalDate tom) {
+        var jpql = new StringBuilder("FROM InntektsmeldingEntitet where arbeidsgiverIdent = :orgnr");
+        if (aktørId != null) {
+            jpql.append(" and aktørId = :aktørId");
+        }
+        if (ytelsetype != null) {
+            jpql.append(" and ytelsetype = :ytelsetype");
+        }
+        if (fom != null) {
+            jpql.append(" and startDato >= :fom");
+        }
+        if (tom != null) {
+            jpql.append(" and startDato <= :tom");
+        }
+        jpql.append(" order by opprettetTidspunkt desc");
+
+        var query = entityManager.createQuery(jpql.toString(), InntektsmeldingEntitet.class)
+            .setParameter("orgnr", orgnr);
+        if (aktørId != null) {
+            query.setParameter("aktørId", aktørId);
+        }
+        if (ytelsetype != null) {
+            query.setParameter("ytelsetype", ytelsetype);
+        }
+        if (fom != null) {
+            query.setParameter("fom", fom);
+        }
+        if (tom != null) {
+            query.setParameter("tom", tom);
+        }
+        return query.getResultList();
     }
 
     public List<InntektsmeldingEntitet> hentInntektsmeldingerForÅr(AktørIdEntitet aktørId, String arbeidsgiverIdent, int år, Ytelsetype ytelsetype) {

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/LpsSystemInfoEntitet.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/LpsSystemInfoEntitet.java
@@ -1,0 +1,88 @@
+package no.nav.familie.inntektsmelding.imdialog.modell;
+
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+@Entity(name = "LpsSystemInfoEntitet")
+@Table(name = "LPS_SYSTEM_INFORMASJON")
+public class LpsSystemInfoEntitet {
+
+    @Id
+    @OneToOne
+    @JoinColumn(name = "inntektsmelding_id", nullable = false, updatable = false, unique = true)
+    private InntektsmeldingEntitet inntektsmelding;
+
+    @Column(name = "navn", length = 100, nullable = false, updatable = false)
+    private String navn;
+
+    @Column(name = "versjon", length = 100, nullable = false, updatable = false)
+    private String versjon;
+
+    public LpsSystemInfoEntitet() {
+        // Hibernate
+    }
+
+    void setInntektsmelding(InntektsmeldingEntitet inntektsmeldingEntitet) {
+        this.inntektsmelding = inntektsmeldingEntitet;
+    }
+
+    public InntektsmeldingEntitet getInntektsmelding() {
+        return inntektsmelding;
+    }
+
+    public String getNavn() {
+        return navn;
+    }
+
+    public String getVersjon() {
+        return versjon;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        var that = (LpsSystemInfoEntitet) o;
+        return Objects.equals(navn, that.navn) && Objects.equals(versjon, that.versjon);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(navn, versjon);
+    }
+
+    @Override
+    public String toString() {
+        return "LpsSystemInfoEntitet{" + "navn='" + navn + '\'' + ", versjon='" + versjon + '\'' + '}';
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private final LpsSystemInfoEntitet kladd = new LpsSystemInfoEntitet();
+
+        public Builder medNavn(String navn) {
+            kladd.navn = navn;
+            return this;
+        }
+
+        public Builder medVersjon(String versjon) {
+            kladd.versjon = versjon;
+            return this;
+        }
+
+        public LpsSystemInfoEntitet build() {
+            Objects.requireNonNull(kladd.navn, "navn");
+            Objects.requireNonNull(kladd.versjon, "versjon");
+            return kladd;
+        }
+    }
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/LpsSystemInfoEntitet.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/LpsSystemInfoEntitet.java
@@ -24,7 +24,7 @@ public class LpsSystemInfoEntitet {
     @Column(name = "versjon", length = 100, nullable = false, updatable = false)
     private String versjon;
 
-    public LpsSystemInfoEntitet() {
+    LpsSystemInfoEntitet() {
         // Hibernate
     }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/OmsorgspengerEntitet.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/OmsorgspengerEntitet.java
@@ -12,7 +12,9 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 
 @Entity(name = "OmsorgspengerEntitet")
 @Table(name = "OMSORGSPENGER")
@@ -104,5 +106,19 @@ public class OmsorgspengerEntitet {
             ", fraværsPerioder=" + fraværsPerioder +
             ", delvisFraværsPerioder=" + delvisFraværsPerioder +
             '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof OmsorgspengerEntitet that)) return false;
+        return harUtbetaltPliktigeDager == that.harUtbetaltPliktigeDager
+            && new HashSet<>(fraværsPerioder).equals(new HashSet<>(that.fraværsPerioder))
+            && new HashSet<>(delvisFraværsPerioder).equals(new HashSet<>(that.delvisFraværsPerioder));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(harUtbetaltPliktigeDager, new HashSet<>(fraværsPerioder), new HashSet<>(delvisFraværsPerioder));
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/PeriodeEntitet.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/PeriodeEntitet.java
@@ -2,6 +2,7 @@ package no.nav.familie.inntektsmelding.imdialog.modell;
 
 
 import java.time.LocalDate;
+import java.util.Objects;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
@@ -58,7 +59,12 @@ public class PeriodeEntitet {
         }
 
         return fom.equals(that.fom)
-            && tom.equals(that.tom) ;
+            && tom.equals(that.tom);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fom, tom);
     }
 
     public boolean overlapper(PeriodeEntitet other) {

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/RefusjonsendringEntitet.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/modell/RefusjonsendringEntitet.java
@@ -2,6 +2,7 @@ package no.nav.familie.inntektsmelding.imdialog.modell;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Objects;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -56,6 +57,19 @@ public class RefusjonsendringEntitet {
             "fom=" + fom +
             ", refusjonPrMnd=" + refusjonPrMnd +
             '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof RefusjonsendringEntitet that)) return false;
+        return Objects.equals(fom, that.fom)
+            && (refusjonPrMnd == null ? that.refusjonPrMnd == null : refusjonPrMnd.compareTo(that.refusjonPrMnd) == 0);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fom, refusjonPrMnd == null ? null : refusjonPrMnd.stripTrailingZeros());
     }
 
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/koder/Kildesystem.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/koder/Kildesystem.java
@@ -1,5 +1,6 @@
 package no.nav.familie.inntektsmelding.koder;
 
 public enum Kildesystem {
-    ARBEIDSGIVERPORTAL
+    ARBEIDSGIVERPORTAL,
+    LØNN_OG_PERSONAL_SYSTEM
 }

--- a/src/main/resources/META-INF/pu-default.imdialog.orm.xml
+++ b/src/main/resources/META-INF/pu-default.imdialog.orm.xml
@@ -10,6 +10,7 @@
     <entity class="no.nav.familie.inntektsmelding.imdialog.modell.FraværsPeriodeEntitet" />
 	<entity class="no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingEntitet" />
     <entity class="no.nav.familie.inntektsmelding.imdialog.modell.KontaktpersonEntitet" />
+    <entity class="no.nav.familie.inntektsmelding.imdialog.modell.LpsSystemInfoEntitet" />
     <entity class="no.nav.familie.inntektsmelding.imdialog.modell.OmsorgspengerEntitet" />
     <entity class="no.nav.familie.inntektsmelding.imdialog.modell.RefusjonsendringEntitet" />
     <entity class="no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet" />

--- a/src/main/resources/db/postgres/defaultDS/V1.0_033__lps_system_informasjon.sql
+++ b/src/main/resources/db/postgres/defaultDS/V1.0_033__lps_system_informasjon.sql
@@ -1,0 +1,11 @@
+create table if not exists lps_system_informasjon (
+    inntektsmelding_id bigint not null
+        constraint pk_lps_system_id primary key
+        constraint fk_lps_system_id references inntektsmelding,
+    navn varchar(100) not null,
+    versjon varchar(100) not null
+);
+comment on table lps_system_informasjon is 'Informasjon om LPS systemet som sendte inntektsmeldingen';
+comment on column lps_system_informasjon.inntektsmelding_id is 'Natural Primary Key og Foreign Key til inntektsmelding';
+comment on column lps_system_informasjon.navn is 'Navn på system som har sendt inntektsmeldingen';
+comment on column lps_system_informasjon.versjon is 'Versjon på system som har sendt inntektsmeldingen';

--- a/src/main/resources/db/postgres/defaultDS/V1.0_033__lps_system_informasjon.sql
+++ b/src/main/resources/db/postgres/defaultDS/V1.0_033__lps_system_informasjon.sql
@@ -1,11 +1,11 @@
-create table if not exists lps_system_informasjon (
-    inntektsmelding_id bigint not null
-        constraint pk_lps_system_id primary key
-        constraint fk_lps_system_id references inntektsmelding,
-    navn varchar(100) not null,
-    versjon varchar(100) not null
+CREATE TABLE LPS_SYSTEM_INFORMASJON (
+    INNTEKTSMELDING_ID BIGINT NOT NULL
+        CONSTRAINT pk_lps_system_id PRIMARY KEY
+        CONSTRAINT fk_lps_system_id REFERENCES INNTEKTSMELDING,
+    NAVN VARCHAR(100) NOT NULL,
+    VERSJON VARCHAR(100) NOT NULL
 );
-comment on table lps_system_informasjon is 'Informasjon om LPS systemet som sendte inntektsmeldingen';
-comment on column lps_system_informasjon.inntektsmelding_id is 'Natural Primary Key og Foreign Key til inntektsmelding';
-comment on column lps_system_informasjon.navn is 'Navn på system som har sendt inntektsmeldingen';
-comment on column lps_system_informasjon.versjon is 'Versjon på system som har sendt inntektsmeldingen';
+COMMENT ON TABLE LPS_SYSTEM_INFORMASJON IS 'Informasjon om LPS systemet som sendte inntektsmeldingen';
+COMMENT ON COLUMN LPS_SYSTEM_INFORMASJON.INNTEKTSMELDING_ID IS 'Natural Primary Key og Foreign Key til inntektsmelding';
+COMMENT ON COLUMN LPS_SYSTEM_INFORMASJON.NAVN IS 'Navn på system som har sendt inntektsmeldingen';
+COMMENT ON COLUMN LPS_SYSTEM_INFORMASJON.VERSJON IS 'Versjon på system som har sendt inntektsmeldingen';

--- a/src/test/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMottakTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMottakTjenesteTest.java
@@ -1,0 +1,273 @@
+package no.nav.familie.inntektsmelding.imapi.inntektsmelding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
+import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
+import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingRepository;
+import no.nav.familie.inntektsmelding.imdialog.modell.KontaktpersonEntitet;
+import no.nav.familie.inntektsmelding.imdialog.modell.LpsSystemInfoEntitet;
+import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.InntektTjeneste;
+import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.Inntektsopplysninger;
+import no.nav.familie.inntektsmelding.koder.ForespørselStatus;
+import no.nav.familie.inntektsmelding.koder.ForespørselType;
+import no.nav.familie.inntektsmelding.koder.InntektsmeldingType;
+import no.nav.familie.inntektsmelding.koder.Kildesystem;
+import no.nav.familie.inntektsmelding.koder.Ytelsetype;
+import no.nav.familie.inntektsmelding.typer.dto.MånedslønnStatus;
+import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
+import no.nav.k9.inntektsmelding.felles.AvsenderSystemDto;
+import no.nav.k9.inntektsmelding.felles.EndringsårsakDto;
+import no.nav.k9.inntektsmelding.felles.EndringsårsakerDto;
+import no.nav.k9.inntektsmelding.felles.FeilkodeDto;
+import no.nav.k9.inntektsmelding.felles.FødselsnummerDto;
+import no.nav.k9.inntektsmelding.felles.KontaktpersonDto;
+import no.nav.k9.inntektsmelding.felles.OrganisasjonsnummerDto;
+import no.nav.k9.inntektsmelding.felles.YtelseTypeDto;
+import no.nav.k9.inntektsmelding.imapi.inntektsmelding.SendInntektsmeldingRequest;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
+
+@ExtendWith(MockitoExtension.class)
+class InntektsmeldingApiMottakTjenesteTest {
+
+    private static final String ORGNR = "999999999";
+    private static final String FNR = "12345678901";
+    private static final UUID FORESPORSEL_UUID = UUID.randomUUID();
+    private static final LocalDate STARTDATO = LocalDate.of(2024, 1, 1);
+    private static final BigDecimal INNTEKT = new BigDecimal("50000");
+    private static final AktørIdEntitet AKTØR_ID = new AktørIdEntitet("1234567890123");
+
+    @Mock
+    private ForespørselBehandlingTjeneste forespørselBehandlingTjeneste;
+    @Mock
+    private InntektsmeldingRepository inntektsmeldingRepository;
+    @Mock
+    private ProsessTaskTjeneste prosessTaskTjeneste;
+    @Mock
+    private InntektTjeneste inntektTjeneste;
+
+    private InntektsmeldingApiMottakTjeneste tjeneste;
+
+    @BeforeEach
+    void setUp() {
+        tjeneste = new InntektsmeldingApiMottakTjeneste(
+            forespørselBehandlingTjeneste, inntektsmeldingRepository, prosessTaskTjeneste, inntektTjeneste);
+    }
+
+    @Test
+    void forespørsel_ikke_funnet_returnerer_feil() {
+        when(forespørselBehandlingTjeneste.hentForespørsel(FORESPORSEL_UUID)).thenReturn(Optional.empty());
+
+        var response = tjeneste.mottaInntektsmelding(lagRequest(), AKTØR_ID);
+
+        assertThat(response.success()).isFalse();
+        assertThat(response.feilinformasjon().feilkode()).isEqualTo(FeilkodeDto.TOM_FORESPOERSEL);
+        verifyNoInteractions(inntektTjeneste, inntektsmeldingRepository, prosessTaskTjeneste);
+    }
+
+    @Test
+    void forespørsel_med_status_utgått_returnerer_feil() {
+        var forespørsel = lagForespørsel();
+        forespørsel.setStatus(ForespørselStatus.UTGÅTT);
+        when(forespørselBehandlingTjeneste.hentForespørsel(FORESPORSEL_UUID)).thenReturn(Optional.of(forespørsel));
+
+        var response = tjeneste.mottaInntektsmelding(lagRequest(), AKTØR_ID);
+
+        assertThat(response.success()).isFalse();
+        assertThat(response.feilinformasjon().feilkode()).isEqualTo(FeilkodeDto.UGYLDIG_FORESPOERSEL);
+        verifyNoInteractions(inntektTjeneste, inntektsmeldingRepository, prosessTaskTjeneste);
+    }
+
+    @Test
+    void duplikat_inntektsmelding_avvises() {
+        var forespørsel = spy(lagForespørsel());
+        var eksisterendeIm = lagMatchendeInntektsmeldingEntitet(forespørsel);
+        when(forespørsel.getInntektsmeldinger()).thenReturn(List.of(eksisterendeIm));
+        when(forespørselBehandlingTjeneste.hentForespørsel(FORESPORSEL_UUID)).thenReturn(Optional.of(forespørsel));
+
+        var response = tjeneste.mottaInntektsmelding(lagRequest(), AKTØR_ID);
+
+        assertThat(response.success()).isFalse();
+        assertThat(response.feilinformasjon().feilkode()).isEqualTo(FeilkodeDto.DUPLIKAT);
+        verifyNoInteractions(inntektTjeneste, inntektsmeldingRepository, prosessTaskTjeneste);
+    }
+
+    @Test
+    void nedetid_ainntekt_returnerer_feil() {
+        var forespørsel = lagForespørsel();
+        when(forespørselBehandlingTjeneste.hentForespørsel(FORESPORSEL_UUID)).thenReturn(Optional.of(forespørsel));
+        when(inntektTjeneste.hentInntekt(any(), any(), any(), any(), any()))
+            .thenReturn(lagInntektsopplysningerMedNedetid());
+
+        var response = tjeneste.mottaInntektsmelding(lagRequest(), AKTØR_ID);
+
+        assertThat(response.success()).isFalse();
+        assertThat(response.feilinformasjon().feilkode()).isEqualTo(FeilkodeDto.NEDETID_AINNTEKT);
+        verifyNoInteractions(inntektsmeldingRepository, prosessTaskTjeneste);
+    }
+
+    @Test
+    void ulik_inntekt_uten_endringsårsak_returnerer_feil() {
+        var forespørsel = lagForespørsel();
+        when(forespørselBehandlingTjeneste.hentForespørsel(FORESPORSEL_UUID)).thenReturn(Optional.of(forespørsel));
+        // Gjennomsnitt 60100 − oppgitt 50000 = diff 10100 > 50 (AKSEPTERT_AVVIK), ingen endringsårsak
+        when(inntektTjeneste.hentInntekt(any(), any(), any(), any(), any()))
+            .thenReturn(new Inntektsopplysninger(new BigDecimal("60100"), ORGNR, List.of()));
+
+        var response = tjeneste.mottaInntektsmelding(lagRequest(), AKTØR_ID);
+
+        assertThat(response.success()).isFalse();
+        assertThat(response.feilinformasjon().feilkode()).isEqualTo(FeilkodeDto.ULIK_INNTEKT);
+        verifyNoInteractions(inntektsmeldingRepository, prosessTaskTjeneste);
+    }
+
+    @Test
+    void ulik_inntekt_med_endringsårsak_godtas() {
+        var forespørsel = lagForespørsel();
+        when(forespørselBehandlingTjeneste.hentForespørsel(FORESPORSEL_UUID)).thenReturn(Optional.of(forespørsel));
+        when(inntektTjeneste.hentInntekt(any(), any(), any(), any(), any()))
+            .thenReturn(new Inntektsopplysninger(new BigDecimal("60100"), ORGNR, List.of()));
+        stubLagring(forespørsel);
+
+        var response = tjeneste.mottaInntektsmelding(lagRequestMedEndringsårsak(), AKTØR_ID);
+
+        assertThat(response.success()).isTrue();
+    }
+
+    @Test
+    void inntekt_innenfor_akseptert_avvik_godtas() {
+        var forespørsel = lagForespørsel();
+        when(forespørselBehandlingTjeneste.hentForespørsel(FORESPORSEL_UUID)).thenReturn(Optional.of(forespørsel));
+        // diff = 50030 − 50000 = 30 ≤ 50 (AKSEPTERT_AVVIK)
+        when(inntektTjeneste.hentInntekt(any(), any(), any(), any(), any()))
+            .thenReturn(new Inntektsopplysninger(new BigDecimal("50030"), ORGNR, List.of()));
+        stubLagring(forespørsel);
+
+        var response = tjeneste.mottaInntektsmelding(lagRequest(), AKTØR_ID);
+
+        assertThat(response.success()).isTrue();
+    }
+
+    @Test
+    void ok_flyt_lagrer_og_ferdigstiller() {
+        var forespørsel = lagForespørsel();
+        when(forespørselBehandlingTjeneste.hentForespørsel(FORESPORSEL_UUID)).thenReturn(Optional.of(forespørsel));
+        when(inntektTjeneste.hentInntekt(any(), any(), any(), any(), any()))
+            .thenReturn(new Inntektsopplysninger(INNTEKT, ORGNR, List.of()));
+        var lagretEntitet = stubLagring(forespørsel);
+
+        var response = tjeneste.mottaInntektsmelding(lagRequest(), AKTØR_ID);
+
+        assertThat(response.success()).isTrue();
+        assertThat(response.inntektsmeldingUuid()).isEqualTo(lagretEntitet.getUuid());
+        verify(inntektsmeldingRepository).lagreInntektsmelding(any());
+        verify(prosessTaskTjeneste).lagre(any(ProsessTaskData.class));
+        verify(forespørselBehandlingTjeneste).ferdigstillForespørsel(eq(FORESPORSEL_UUID), any(), any(), any(), any());
+    }
+
+    // ---- Hjelpemetoder ----
+
+    private SendInntektsmeldingRequest lagRequest() {
+        return new SendInntektsmeldingRequest(
+            FORESPORSEL_UUID,
+            new FødselsnummerDto(FNR),
+            new OrganisasjonsnummerDto(ORGNR),
+            STARTDATO,
+            YtelseTypeDto.PLEIEPENGER_SYKT_BARN,
+            new KontaktpersonDto("Ola Nordmann", "12345678"),
+            INNTEKT,
+            List.of(),
+            List.of(),
+            List.of(),
+            new AvsenderSystemDto("TestSystem", "1.0")
+        );
+    }
+
+    private SendInntektsmeldingRequest lagRequestMedEndringsårsak() {
+        return new SendInntektsmeldingRequest(
+            FORESPORSEL_UUID,
+            new FødselsnummerDto(FNR),
+            new OrganisasjonsnummerDto(ORGNR),
+            STARTDATO,
+            YtelseTypeDto.PLEIEPENGER_SYKT_BARN,
+            new KontaktpersonDto("Ola Nordmann", "12345678"),
+            INNTEKT,
+            List.of(),
+            List.of(),
+            List.of(new EndringsårsakerDto(EndringsårsakDto.TARIFFENDRING, null, null, null)),
+            new AvsenderSystemDto("TestSystem", "1.0")
+        );
+    }
+
+    private ForespørselEntitet lagForespørsel() {
+        return ForespørselEntitet.builder()
+            .medOrganisasjonsnummer(ORGNR)
+            .medSkjæringstidspunkt(STARTDATO)
+            .medAktørId(AKTØR_ID)
+            .medYtelseType(Ytelsetype.PLEIEPENGER_SYKT_BARN)
+            .medForespørselType(ForespørselType.BESTILT_AV_FAGSYSTEM)
+            .build();
+    }
+
+    /**
+     * Bygger en InntektsmeldingEntitet med de samme feltverdiene som
+     * InntektsmeldingApiMapper ville produsert fra lagRequest(), slik at
+     * duplikat-sjekken i inntektsmeldingerErLike() slår til.
+     */
+    private InntektsmeldingEntitet lagMatchendeInntektsmeldingEntitet(ForespørselEntitet forespørsel) {
+        return InntektsmeldingEntitet.builder()
+            .medAktørId(AKTØR_ID)
+            .medArbeidsgiverIdent(ORGNR)
+            .medMånedInntekt(INNTEKT)
+            .medKildesystem(Kildesystem.LØNN_OG_PERSONAL_SYSTEM)
+            .medInntektsmeldingType(InntektsmeldingType.ORDINÆR)
+            .medStartDato(STARTDATO)
+            .medYtelsetype(Ytelsetype.PLEIEPENGER_SYKT_BARN)
+            .medKontaktperson(new KontaktpersonEntitet("Ola Nordmann", "12345678"))
+            .medEndringsårsaker(List.of())
+            .medBortfaltNaturalytelser(List.of())
+            .medRefusjonsendringer(List.of())
+            .medLpsSystemInfo(LpsSystemInfoEntitet.builder()
+                .medNavn("TestSystem")
+                .medVersjon("1.0")
+                .build())
+            .medForespørsel(forespørsel)
+            .build();
+    }
+
+    private Inntektsopplysninger lagInntektsopplysningerMedNedetid() {
+        return new Inntektsopplysninger(null, ORGNR,
+            List.of(new Inntektsopplysninger.InntektMåned(null, YearMonth.now().minusMonths(1), MånedslønnStatus.NEDETID_AINNTEKT)));
+    }
+
+    private InntektsmeldingEntitet stubLagring(ForespørselEntitet forespørsel) {
+        var lagretEntitet = lagMatchendeInntektsmeldingEntitet(forespørsel);
+        when(inntektsmeldingRepository.lagreInntektsmelding(any())).thenReturn(1L);
+        when(inntektsmeldingRepository.hentInntektsmelding(1L)).thenReturn(lagretEntitet);
+        return lagretEntitet;
+    }
+}
+
+
+

--- a/src/test/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiRestTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiRestTest.java
@@ -1,0 +1,160 @@
+package no.nav.familie.inntektsmelding.imapi.inntektsmelding;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
+import no.nav.familie.inntektsmelding.server.tilgangsstyring.Tilgang;
+import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
+import no.nav.k9.inntektsmelding.felles.AvsenderSystemDto;
+import no.nav.k9.inntektsmelding.felles.FeilkodeDto;
+import no.nav.k9.inntektsmelding.felles.FødselsnummerDto;
+import no.nav.k9.inntektsmelding.felles.KontaktpersonDto;
+import no.nav.k9.inntektsmelding.felles.OrganisasjonsnummerDto;
+import no.nav.k9.inntektsmelding.felles.YtelseTypeDto;
+import no.nav.k9.inntektsmelding.imapi.inntektsmelding.HentInntektsmeldingerRequest;
+import no.nav.k9.inntektsmelding.imapi.inntektsmelding.HentInntektsmeldingerResponse;
+import no.nav.k9.inntektsmelding.imapi.inntektsmelding.InntektsmeldingDto;
+import no.nav.k9.inntektsmelding.imapi.inntektsmelding.SendInntektsmeldingRequest;
+import no.nav.k9.inntektsmelding.imapi.inntektsmelding.SendInntektsmeldingResponse;
+
+@ExtendWith(MockitoExtension.class)
+class InntektsmeldingApiRestTest {
+    private static final String ORGNUMMER = "974760673";
+    private static final String FNR = "11111111111";
+
+    private InntektsmeldingApiRest inntektsmeldingApiRest;
+    @Mock
+    private Tilgang tilgang;
+    @Mock
+    private InntektsmeldingApiTjeneste inntektsmeldingApiTjeneste;
+    @Mock
+    private InntektsmeldingApiMottakTjeneste mottakTjeneste;
+    @Mock
+    private PersonTjeneste personTjeneste;
+
+    @BeforeEach
+    void setUp() {
+        inntektsmeldingApiRest = new InntektsmeldingApiRest(inntektsmeldingApiTjeneste, mottakTjeneste, personTjeneste, tilgang);
+    }
+
+    @Test
+    void skal_hente_inntektsmelding() {
+        var inntektsmeldingUuid = UUID.randomUUID();
+        var forventetDto = lagInntektsmeldingDto(inntektsmeldingUuid, UUID.randomUUID());
+        when(inntektsmeldingApiTjeneste.hentInntektsmelding(inntektsmeldingUuid)).thenReturn(Optional.of(forventetDto));
+
+        var response = inntektsmeldingApiRest.hentInntektsmelding(inntektsmeldingUuid);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK_200);
+        assertThat(response.getEntity()).isEqualTo(forventetDto);
+        verify(inntektsmeldingApiTjeneste).hentInntektsmelding(inntektsmeldingUuid);
+    }
+
+    @Test
+    void skal_returnere_404_når_inntektsmelding_ikke_finnes() {
+        var inntektsmeldingUuid = UUID.randomUUID();
+        when(inntektsmeldingApiTjeneste.hentInntektsmelding(inntektsmeldingUuid)).thenReturn(Optional.empty());
+
+        var response = inntektsmeldingApiRest.hentInntektsmelding(inntektsmeldingUuid);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND_404);
+    }
+
+    @Test
+    void skal_sende_inntektsmelding_ok() {
+        var forespørselUuid = UUID.randomUUID();
+        var inntektsmeldingUuid = UUID.randomUUID();
+        var aktørId = new AktørIdEntitet("1234567890123");
+        var request = lagSendInntektsmeldingRequest(forespørselUuid);
+        var forventetSvar = new SendInntektsmeldingResponse(true, inntektsmeldingUuid, null);
+
+        when(personTjeneste.finnAktørIdForPersonIdent(FNR)).thenReturn(Optional.of(aktørId));
+        when(mottakTjeneste.mottaInntektsmelding(request, aktørId)).thenReturn(forventetSvar);
+
+        var svar = inntektsmeldingApiRest.sendInntektsmelding(request);
+
+        assertThat(svar.success()).isTrue();
+        assertThat(svar.inntektsmeldingUuid()).isEqualTo(inntektsmeldingUuid);
+        verify(mottakTjeneste).mottaInntektsmelding(request, aktørId);
+    }
+
+    @Test
+    void skal_returnere_feil_ved_ingen_aktørId() {
+        var forespørselUuid = UUID.randomUUID();
+        var request = lagSendInntektsmeldingRequest(forespørselUuid);
+
+        when(personTjeneste.finnAktørIdForPersonIdent(FNR)).thenReturn(Optional.empty());
+
+        var svar = inntektsmeldingApiRest.sendInntektsmelding(request);
+
+        assertThat(svar.success()).isFalse();
+        assertThat(svar.feilinformasjon().feilkode()).isEqualTo(FeilkodeDto.INGEN_AKTØR_ID);
+    }
+
+    @Test
+    void skal_hente_inntektsmeldinger_med_filter() {
+        var forespørselUuid = UUID.randomUUID();
+        var inntektsmeldingUuid = UUID.randomUUID();
+        var filterRequest = new HentInntektsmeldingerRequest(new OrganisasjonsnummerDto(ORGNUMMER), null, null, null, null, null);
+        var forventetDto = lagInntektsmeldingDto(inntektsmeldingUuid, forespørselUuid);
+        when(inntektsmeldingApiTjeneste.hentInntektsmeldinger(filterRequest)).thenReturn(List.of(forventetDto));
+
+        var response = inntektsmeldingApiRest.hentInntektsmeldinger(filterRequest);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK_200);
+        assertThat(((HentInntektsmeldingerResponse) response.getEntity()).inntektsmeldinger()).asList().containsExactly(forventetDto);
+        verify(inntektsmeldingApiTjeneste).hentInntektsmeldinger(filterRequest);
+    }
+
+    private InntektsmeldingDto lagInntektsmeldingDto(UUID inntektsmeldingUuid, UUID forespørselUuid) {
+        return new InntektsmeldingDto(
+            inntektsmeldingUuid,
+            forespørselUuid,
+            new FødselsnummerDto(FNR),
+            YtelseTypeDto.PLEIEPENGER_SYKT_BARN,
+            new OrganisasjonsnummerDto(ORGNUMMER),
+            new KontaktpersonDto("Kontakt Person", "99999999"),
+            LocalDate.now(),
+            new BigDecimal("50000"),
+            LocalDateTime.now(),
+            null,
+            null,
+            new AvsenderSystemDto("NAV_NO", "1.0"),
+            List.of(),
+            List.of(),
+            List.of()
+        );
+    }
+
+    private SendInntektsmeldingRequest lagSendInntektsmeldingRequest(UUID forespørselUuid) {
+        return new SendInntektsmeldingRequest(
+            forespørselUuid,
+            new FødselsnummerDto(FNR),
+            new OrganisasjonsnummerDto(ORGNUMMER),
+            LocalDate.now(),
+            YtelseTypeDto.PLEIEPENGER_SYKT_BARN,
+            new KontaktpersonDto("Kontakt Person", "99999999"),
+            new BigDecimal("50000"),
+            List.of(),
+            List.of(),
+            List.of(),
+            null
+        );
+    }
+}


### PR DESCRIPTION
### Behov / Bakgrunn
K9-inntektsmelding-api skal hente og sende inntektsmeldinger til k9-inntektsmelding. 

### Løsning
Legger til tilsvarende endepunkt som foreldrepenger har

### Andre endringer


---

### Sjekkliste for godkjenner

- [x] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [x] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [x] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
