### PR TITLE
Legg til config for maskintoken for å kalle dialogporten

### DIFF
--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -76,6 +76,11 @@ spec:
       -  name: k9_inntektsmelding_statistikk_dataset
          description: Inneholder tabeller for k9-inntektsmelding statistikk
          permission: READWRITE
+  maskinporten:
+    enabled: true
+    scopes:
+      consumes:
+        - name: "digdir:dialogporten.serviceprovider"
   tokenx:
     enabled: true
   azure:
@@ -121,8 +126,10 @@ spec:
         - host: aareg-services.{{environment}}-fss-pub.nais.io
       {{#if devOnly}}
         - host: dokarkiv-q2.{{environment}}-fss-pub.nais.io
+        - host: platform.tt02.altinn.no
       {{else}}
         - host: dokarkiv.{{environment}}-fss-pub.nais.io
+        - host: platform.altinn.no
       {{/if}}
   env:
     - name: gruppe.oid.drift


### PR DESCRIPTION
### Behov / Bakgrunn
For å kalle på dialogporten må vi legge til config for maskinporten-token

### Løsning
Legger til samme config som fp-inntektsmelding bruker

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
