### PR TITLE
Legg til ForespørselApiRest og InntektsmeldingApiRest i ApiConfig

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/server/app/api/ApiConfig.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/server/app/api/ApiConfig.java
@@ -15,6 +15,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import no.nav.familie.inntektsmelding.forespørsel.rest.ForespørselRest;
+import no.nav.familie.inntektsmelding.imapi.forespørsel.ForespørselApiRest;
+import no.nav.familie.inntektsmelding.imapi.inntektsmelding.InntektsmeldingApiRest;
 import no.nav.familie.inntektsmelding.imdialog.rest.InntektsmeldingDialogRest;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.RefusjonOmsorgsdagerRest;
 import no.nav.familie.inntektsmelding.server.auth.AutentiseringFilter;
@@ -56,7 +58,9 @@ public class ApiConfig extends ResourceConfig {
         return Set.of(ForespørselRest.class,
             InntektsmeldingDialogRest.class,
             RefusjonOmsorgsdagerRest.class,
-            ArbeidsgiverinitiertDialogRest.class);
+            ArbeidsgiverinitiertDialogRest.class,
+            ForespørselApiRest.class,
+            InntektsmeldingApiRest.class);
     }
 
     private Map<String, Object> getApplicationProperties() {


### PR DESCRIPTION
### Behov / Bakgrunn
De nye rest tjenestene ForespørselApiRest og InntektsmeldingApiRest var ikke tilgjengelige.

### Løsning
Legger dem til i ApiConfig.

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
