### PR TITLE
Fix: maskere orgnr i loggene

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -325,7 +325,7 @@ public class ForespørselBehandlingTjeneste {
         }
 
         LOG.info("Setter forespørsel til utgått, orgnr: {}, stp: {}, saksnr: {}, ytelse: {}",
-            eksisterendeForespørsel.getOrganisasjonsnummer(),
+            new OrganisasjonsnummerDto(eksisterendeForespørsel.getOrganisasjonsnummer()),
             eksisterendeForespørsel.getSkjæringstidspunkt(),
             eksisterendeForespørsel.getSaksnummer().orElse(null),
             eksisterendeForespørsel.getYtelseType());
@@ -340,7 +340,7 @@ public class ForespørselBehandlingTjeneste {
         forespørselTjeneste.ferdigstillForespørsel(eksisterendeForespørsel.getArbeidsgiverNotifikasjonSakId());
 
         LOG.info("Gjenåpner forespørsel, orgnr: {}, stp: {}, saksnr: {}, ytelse: {}",
-            eksisterendeForespørsel.getOrganisasjonsnummer(),
+            new OrganisasjonsnummerDto(eksisterendeForespørsel.getOrganisasjonsnummer()),
             eksisterendeForespørsel.getSkjæringstidspunkt(),
             eksisterendeForespørsel.getSaksnummer().orElse(null),
             eksisterendeForespørsel.getYtelseType());
@@ -470,7 +470,7 @@ public class ForespørselBehandlingTjeneste {
                                                                          LocalDate skjæringstidspunkt,
                                                                          Ytelsetype ytelsetype,
                                                                          ForespørselType forespørselType) {
-        LOG.info("Oppretter forespørsel for arbeidsgiverinitiert inntektsmelding, orgnr: {}, stp: {}, aktørId: {}, ytelse: {}", organisasjonsnummer.orgnr(), skjæringstidspunkt, aktørId.getAktørId(), ytelsetype);
+        LOG.info("Oppretter forespørsel for arbeidsgiverinitiert inntektsmelding, orgnr: {}, stp: {}, aktørId: {}, ytelse: {}", organisasjonsnummer, skjæringstidspunkt, aktørId.getAktørId(), ytelsetype);
 
         // opprettt forespørsel i databasen
         var forespørselUuid = forespørselTjeneste.opprettForespørselUtenFagsaksnummer(skjæringstidspunkt, aktørId, organisasjonsnummer, ytelsetype, forespørselType);

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTask.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/task/OpprettForespørselTask.java
@@ -58,7 +58,7 @@ public class OpprettForespørselTask implements ProsessTaskHandler {
 
         if (eksisterendeForespørsler.stream().anyMatch(eksisterende -> !eksisterende.getStatus().equals(ForespørselStatus.UTGÅTT))) {
             LOG.info("Forespørsel finnes allerede, orgnr: {}, stp: {}, saksnr: {}, ytelse: {}",
-                organisasjonsnummer.orgnr(), skjæringstidspunkt, saksnummer.saksnr(), ytelsetype);
+                organisasjonsnummer, skjæringstidspunkt, saksnummer.saksnr(), ytelsetype);
             return;
         }
 


### PR DESCRIPTION
### Behov / Bakgrunn
Orgnr skal maskeres for logging

### Løsning
Orgnr wrappes i OrganisasjonsnummerDto for automatisk maskering i toString

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
