### PR TITLE
Fiks: Fjern @NotNull fra inntektsmelding-api kontrakene med lister som kan være tomme

### DIFF
--- a/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/inntektsmelding/InntektsmeldingDto.java
+++ b/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/inntektsmelding/InntektsmeldingDto.java
@@ -35,9 +35,9 @@ public record InntektsmeldingDto(
     @Min(0) @Max(Integer.MAX_VALUE) @Digits(integer = 20, fraction = 2) BigDecimal refusjonPrMnd,
     LocalDate opphørsdatoRefusjon,
     @NotNull @Valid AvsenderSystemDto avsenderSystem,
-    @NotNull List<@Valid RefusjonDto> refusjonsendringer,
-    @NotNull List<@Valid BortfaltNaturalytelseDto> bortfaltNaturalytelsePerioder,
-    @NotNull List<@Valid EndringsårsakerDto> endringAvInntektÅrsaker,
+    List<@Valid RefusjonDto> refusjonsendringer,
+    List<@Valid BortfaltNaturalytelseDto> bortfaltNaturalytelsePerioder,
+    List<@Valid EndringsårsakerDto> endringAvInntektÅrsaker,
     @Valid OmsorgspengerDto omsorgspenger
 ) {
 

--- a/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/inntektsmelding/SendInntektsmeldingRequest.java
+++ b/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/inntektsmelding/SendInntektsmeldingRequest.java
@@ -29,9 +29,9 @@ public record SendInntektsmeldingRequest(@NotNull @Valid UUID foresporselUuid,
                                          @NotNull YtelseTypeDto ytelseType,
                                          @NotNull @Valid KontaktpersonDto kontaktperson,
                                          @NotNull @Min(0) @Max(Integer.MAX_VALUE) @Digits(integer = 20, fraction = 2) BigDecimal inntekt,
-                                         @NotNull List<@Valid RefusjonDto> refusjon,
-                                         @NotNull List<@Valid BortfaltNaturalytelseDto> bortfaltNaturalytelsePerioder,
-                                         @NotNull List<@Valid EndringsårsakerDto> endringAvInntektÅrsaker,
+                                         List<@Valid RefusjonDto> refusjon,
+                                         List<@Valid BortfaltNaturalytelseDto> bortfaltNaturalytelsePerioder,
+                                         List<@Valid EndringsårsakerDto> endringAvInntektÅrsaker,
                                          @NotNull @Valid AvsenderSystemDto avsenderSystem,
                                          @Valid OmsorgspengerDto omsorgspenger) {
 


### PR DESCRIPTION
### Behov / Bakgrunn
Default object mapper i rest tjenestene fjerner tomme lister og setter så vi får null.

### Løsning
Fjerner @NotNull annotasjoner som ikke stemmer.


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
