### PR TITLE
Nytt endepunkt for henting av forespørsler for et saksnummer

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/rest/ForespørselRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/rest/ForespørselRest.java
@@ -83,7 +83,7 @@ public class ForespørselRest {
     public Response opprettForespørsel(@Valid @NotNull OpprettForespørselRequest request){
         // dette endepunktet brukes av saksbehandlere for å opprette innteksmelding forespørsel på en valgt dato for å få med varig lønnsendring.
         LOG.info("Mottok request om opprettelse av inntektsmelding forespørsel fra k9-sak på saksnummer {}", request.saksnummer().saksnr());
-        tilgang.sjekkAtSaksbehandlerHarTilgangTilSak(request.saksnummer().saksnr(), BeskyttetRessursActionAttributt.CREATE);
+        tilgang.sjekkAtAnsattHarTilgangTilSak(request.saksnummer().saksnr(), BeskyttetRessursActionAttributt.CREATE);
 
         List<ForespørselEntitet> eksisterendeForespørsler = forespørselBehandlingTjeneste.hentForespørslerForFagsak(request.saksnummer(), null, null);
 
@@ -221,7 +221,7 @@ public class ForespørselRest {
     public Response sendNyBeskjedOgVarsel(@Valid @NotNull NyBeskjedRequest request) {
         LOG.info("Ny beskjed på aktiv forespørsel for saksnummer {} med orgnummer {}", request.saksnummer(), request.orgnr());
 
-        tilgang.sjekkAtSaksbehandlerHarTilgangTilSak(request.saksnummer().saksnr(), BeskyttetRessursActionAttributt.CREATE);
+        tilgang.sjekkAtAnsattHarTilgangTilSak(request.saksnummer().saksnr(), BeskyttetRessursActionAttributt.CREATE);
 
         var resultat = forespørselBehandlingTjeneste.opprettNyBeskjedMedEksternVarsling(request.saksnummer(), request.orgnr(), request.skjæringstidspunkt());
         return Response.ok(new SendNyBeskjedResponse(resultat)).build();

--- a/src/main/java/no/nav/familie/inntektsmelding/forvaltning/OppgaverForvaltningRestTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forvaltning/OppgaverForvaltningRestTjeneste.java
@@ -123,6 +123,7 @@ public class OppgaverForvaltningRestTjeneste {
     @Path(HENT_FORESPØRSLER_FOR_SAK_PATH)
     @Operation(description = "Henter forespørsler for et saksnummer", summary = "Henter forespørsler for et saksnummer.", tags = "oppgaver", responses = {
         @ApiResponse(responseCode = "200", description = "Forespørsler hentet", content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "404", description = "Fant ingen forespørsler for saksnummer"),
         @ApiResponse(responseCode = "500", description = "Feilet pga ukjent feil eller tekniske/funksjonelle feil")
     })
     @Tilgangskontrollert
@@ -132,6 +133,10 @@ public class OppgaverForvaltningRestTjeneste {
 
         sjekkAtKallerHarRollenDriftOgTilgangTilSak(saksnummer);
         List<ForespørselEntitet> forespørsler = forespørselBehandlingTjeneste.hentForespørslerForFagsak(new SaksnummerDto(saksnummer), null, null);
+
+        if (forespørsler.isEmpty()) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
 
         sporingsloggTjeneste.logg(BASE_PATH + HENT_FORESPØRSLER_FOR_SAK_PATH,
             new AktørIdDto(hentAktørIdFraForespørsler(forespørsler).getAktørId()),

--- a/src/main/java/no/nav/familie/inntektsmelding/forvaltning/OppgaverForvaltningRestTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forvaltning/OppgaverForvaltningRestTjeneste.java
@@ -9,10 +9,14 @@ import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -104,19 +108,18 @@ public class OppgaverForvaltningRestTjeneste {
     protected record GjenopprettLukketForesporselRequest(@NotNull @Valid UUID forespørselUuid) {
     }
 
-    @POST
+    @GET
     @Path("/foresporsler")
-    @Consumes(MediaType.APPLICATION_JSON)
     @Operation(description = "Henter forespørsler for et saksnummer", summary = "Henter forespørsler for et saksnummer.", tags = "oppgaver", responses = {
         @ApiResponse(responseCode = "200", description = "Forespørsler hentet", content = @Content(mediaType = "application/json")),
         @ApiResponse(responseCode = "500", description = "Feilet pga ukjent feil eller tekniske/funksjonelle feil")
     })
     @Tilgangskontrollert
     public Response hentForespørslerForSak(
-        @Parameter(description = "Saksnummer det skal hentes forespørsler for") @Valid @NotNull HentForespørslerRequest request) {
+        @Parameter(description = "Saksnummer det skal hentes forespørsler for") @Valid @NotNull @Pattern(regexp = SaksnummerDto.REGEXP) @Size(max = 19) @QueryParam("saksnummer") String saksnummer) {
         sjekkAtKallerHarRollenDrift();
-        LOG.info("Henter forespørsler for saksnummer {}", request.saksnummer());
-        List<ForespørselEntitet> forespørsler = forespørselBehandlingTjeneste.hentForespørslerForFagsak(request.saksnummer(), null, null);
+        LOG.info("Henter forespørsler for saksnummer {}", saksnummer);
+        List<ForespørselEntitet> forespørsler = forespørselBehandlingTjeneste.hentForespørslerForFagsak(new SaksnummerDto(saksnummer), null, null);
 
         List<ForvaltningForespørselDto> response = forespørsler.stream()
             .map(f -> new ForvaltningForespørselDto(
@@ -134,8 +137,6 @@ public class OppgaverForvaltningRestTjeneste {
         return Response.ok(response).build();
     }
 
-    protected record HentForespørslerRequest(@Valid @NotNull SaksnummerDto saksnummer) {
-    }
 
     private void sjekkAtKallerHarRollenDrift() {
         tilgang.sjekkAtAnsattHarRollenDrift();

--- a/src/main/java/no/nav/familie/inntektsmelding/forvaltning/OppgaverForvaltningRestTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forvaltning/OppgaverForvaltningRestTjeneste.java
@@ -34,23 +34,31 @@ import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandl
 import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselTekster;
 import no.nav.familie.inntektsmelding.forespørsel.tjenester.LukkeÅrsak;
 import no.nav.familie.inntektsmelding.forvaltning.rest.ForvaltningForespørselDto;
+import no.nav.familie.inntektsmelding.server.audit.SporingsloggTjeneste;
 import no.nav.familie.inntektsmelding.server.auth.api.AutentisertMedAzure;
 import no.nav.familie.inntektsmelding.server.auth.api.Tilgangskontrollert;
 import no.nav.familie.inntektsmelding.server.tilgangsstyring.Tilgang;
+import no.nav.familie.inntektsmelding.typer.dto.AktørIdDto;
 import no.nav.familie.inntektsmelding.typer.dto.OrganisasjonsnummerDto;
 import no.nav.familie.inntektsmelding.typer.dto.SaksnummerDto;
+import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
+import no.nav.sif.abac.kontrakt.abac.BeskyttetRessursActionAttributt;
 
 @AutentisertMedAzure
 @OpenAPIDefinition(tags = @Tag(name = "oppgaver", description = "Hånstering av feilopprettede saker / oppgaver i arbeidsgiverportalen"))
 @RequestScoped
 @Transactional
 @Produces(MediaType.APPLICATION_JSON)
-@Path("/forvaltning-oppgaver")
+@Path(OppgaverForvaltningRestTjeneste.BASE_PATH)
 public class OppgaverForvaltningRestTjeneste {
-
     private static final Logger LOG = LoggerFactory.getLogger(OppgaverForvaltningRestTjeneste.class);
+    public static final String BASE_PATH = "/forvaltning-oppgaver";
+    private static final String SLETT_OPPGAVE_PATH = "/slettOppgave";
+    private static final String GJENOPPRETT_LUKKET_FORESPØRSEL_PATH = "/gjenopprett-lukket-foresporsel";
+    private static final String HENT_FORESPØRSLER_FOR_SAK_PATH = "/foresporsler";
 
     private Tilgang tilgang;
+    private SporingsloggTjeneste sporingsloggTjeneste;
     private ForespørselBehandlingTjeneste forespørselBehandlingTjeneste;
 
     OppgaverForvaltningRestTjeneste() {
@@ -58,13 +66,16 @@ public class OppgaverForvaltningRestTjeneste {
     }
 
     @Inject
-    public OppgaverForvaltningRestTjeneste(Tilgang tilgang, ForespørselBehandlingTjeneste forespørselBehandlingTjeneste) {
+    public OppgaverForvaltningRestTjeneste(Tilgang tilgang,
+                                           SporingsloggTjeneste sporingsloggTjeneste,
+                                           ForespørselBehandlingTjeneste forespørselBehandlingTjeneste) {
         this.tilgang = tilgang;
+        this.sporingsloggTjeneste = sporingsloggTjeneste;
         this.forespørselBehandlingTjeneste = forespørselBehandlingTjeneste;
     }
 
     @POST
-    @Path("/slettOppgave")
+    @Path(SLETT_OPPGAVE_PATH)
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(description = "Sletter en oppgave i arbeidsgiverportalen", summary = "Sletter en oppgave i arbeidsgiverportalen.", tags = "oppgaver", responses = {
         @ApiResponse(responseCode = "202", description = "Oppgaven er slettet", content = @Content(mediaType = "application/json")),
@@ -83,7 +94,7 @@ public class OppgaverForvaltningRestTjeneste {
     }
 
     @POST
-    @Path("/gjenopprett-lukket-foresporsel")
+    @Path(GJENOPPRETT_LUKKET_FORESPØRSEL_PATH)
     @Consumes(MediaType.APPLICATION_JSON)
 @Operation(description = "Gjenoppretter forespørsel som er lukket av LPS eller altinn", summary = "Gjenoppretter forespørsel som er lukket av LPS eller altinn.", tags = "oppgaver", responses = {
     @ApiResponse(responseCode = "200", description = "Gjenoppretting utført", content = @Content(mediaType = "application/json")),
@@ -109,7 +120,7 @@ public class OppgaverForvaltningRestTjeneste {
     }
 
     @GET
-    @Path("/foresporsler")
+    @Path(HENT_FORESPØRSLER_FOR_SAK_PATH)
     @Operation(description = "Henter forespørsler for et saksnummer", summary = "Henter forespørsler for et saksnummer.", tags = "oppgaver", responses = {
         @ApiResponse(responseCode = "200", description = "Forespørsler hentet", content = @Content(mediaType = "application/json")),
         @ApiResponse(responseCode = "500", description = "Feilet pga ukjent feil eller tekniske/funksjonelle feil")
@@ -117,9 +128,14 @@ public class OppgaverForvaltningRestTjeneste {
     @Tilgangskontrollert
     public Response hentForespørslerForSak(
         @Parameter(description = "Saksnummer det skal hentes forespørsler for") @Valid @NotNull @Pattern(regexp = SaksnummerDto.REGEXP) @Size(max = 19) @QueryParam("saksnummer") String saksnummer) {
-        sjekkAtKallerHarRollenDrift();
         LOG.info("Henter forespørsler for saksnummer {}", saksnummer);
+
+        sjekkAtKallerHarRollenDriftOgTilgangTilSak(saksnummer);
         List<ForespørselEntitet> forespørsler = forespørselBehandlingTjeneste.hentForespørslerForFagsak(new SaksnummerDto(saksnummer), null, null);
+
+        sporingsloggTjeneste.logg(BASE_PATH + HENT_FORESPØRSLER_FOR_SAK_PATH,
+            new AktørIdDto(hentAktørIdFraForespørsler(forespørsler).getAktørId()),
+            new SaksnummerDto(saksnummer));
 
         List<ForvaltningForespørselDto> response = forespørsler.stream()
             .map(f -> new ForvaltningForespørselDto(
@@ -137,8 +153,26 @@ public class OppgaverForvaltningRestTjeneste {
         return Response.ok(response).build();
     }
 
-
     private void sjekkAtKallerHarRollenDrift() {
         tilgang.sjekkAtAnsattHarRollenDrift();
+    }
+
+    private void sjekkAtKallerHarRollenDriftOgTilgangTilSak(String saksnummer) {
+        tilgang.sjekkAtAnsattHarRollenDrift();
+        tilgang.sjekkAtAnsattHarTilgangTilSak(saksnummer, BeskyttetRessursActionAttributt.READ);
+    }
+
+    private AktørIdEntitet hentAktørIdFraForespørsler(List<ForespørselEntitet> forespørsler) {
+        if (forespørsler.isEmpty()) {
+            throw new IllegalArgumentException("Forespørsler kan ikke være tom");
+        }
+
+        AktørIdEntitet førsteAktørId = forespørsler.getFirst().getAktørId();
+        boolean alleHarSammeAktørId = forespørsler.stream().allMatch(f -> f.getAktørId().equals(førsteAktørId));
+        if (!alleHarSammeAktørId) {
+            throw new IllegalStateException("Alle forespørsler må ha samme aktørId");
+        }
+
+        return førsteAktørId;
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/forvaltning/OppgaverForvaltningRestTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forvaltning/OppgaverForvaltningRestTjeneste.java
@@ -1,5 +1,6 @@
 package no.nav.familie.inntektsmelding.forvaltning;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -28,6 +29,7 @@ import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
 import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
 import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselTekster;
 import no.nav.familie.inntektsmelding.forespørsel.tjenester.LukkeÅrsak;
+import no.nav.familie.inntektsmelding.forvaltning.rest.ForvaltningForespørselDto;
 import no.nav.familie.inntektsmelding.server.auth.api.AutentisertMedAzure;
 import no.nav.familie.inntektsmelding.server.auth.api.Tilgangskontrollert;
 import no.nav.familie.inntektsmelding.server.tilgangsstyring.Tilgang;
@@ -100,6 +102,39 @@ public class OppgaverForvaltningRestTjeneste {
     }
 
     protected record GjenopprettLukketForesporselRequest(@NotNull @Valid UUID forespørselUuid) {
+    }
+
+    @POST
+    @Path("/foresporsler")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(description = "Henter forespørsler for et saksnummer", summary = "Henter forespørsler for et saksnummer.", tags = "oppgaver", responses = {
+        @ApiResponse(responseCode = "200", description = "Forespørsler hentet", content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "500", description = "Feilet pga ukjent feil eller tekniske/funksjonelle feil")
+    })
+    @Tilgangskontrollert
+    public Response hentForespørslerForSak(
+        @Parameter(description = "Saksnummer det skal hentes forespørsler for") @Valid @NotNull HentForespørslerRequest request) {
+        sjekkAtKallerHarRollenDrift();
+        LOG.info("Henter forespørsler for saksnummer {}", request.saksnummer());
+        List<ForespørselEntitet> forespørsler = forespørselBehandlingTjeneste.hentForespørslerForFagsak(request.saksnummer(), null, null);
+
+        List<ForvaltningForespørselDto> response = forespørsler.stream()
+            .map(f -> new ForvaltningForespørselDto(
+                f.getUuid(),
+                f.getSkjæringstidspunkt(),
+                f.getOrganisasjonsnummer(),
+                f.getAktørId().getAktørId(),
+                f.getYtelseType().toString(),
+                f.getStatus(),
+                f.getOpprettetTidspunkt(),
+                f.getDialogportenUuid().orElse(null),
+                f.getEtterspurtePerioder()))
+            .toList();
+
+        return Response.ok(response).build();
+    }
+
+    protected record HentForespørslerRequest(@Valid @NotNull SaksnummerDto saksnummer) {
     }
 
     private void sjekkAtKallerHarRollenDrift() {

--- a/src/main/java/no/nav/familie/inntektsmelding/forvaltning/rest/ForvaltningForespørselDto.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forvaltning/rest/ForvaltningForespørselDto.java
@@ -1,0 +1,21 @@
+package no.nav.familie.inntektsmelding.forvaltning.rest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import no.nav.familie.inntektsmelding.koder.ForespørselStatus;
+import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
+
+public record ForvaltningForespørselDto(
+    UUID uuid,
+    LocalDate skjæringstidspunkt,
+    String arbeidsgiverident,
+    String aktørid,
+    String ytelsetype,
+    ForespørselStatus status,
+    LocalDateTime opprettetTidspunkt,
+    UUID dialogportenUuid,
+    List<PeriodeDto> etterspurtePerioder) {
+}

--- a/src/main/java/no/nav/familie/inntektsmelding/server/tilgangsstyring/Tilgang.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/server/tilgangsstyring/Tilgang.java
@@ -53,7 +53,7 @@ public interface Tilgang {
      *
      * @throws no.nav.vedtak.exception.ManglerTilgangException om tilgangen ikke er gitt.
      */
-    void sjekkAtSaksbehandlerHarTilgangTilSak(String saksnummer, BeskyttetRessursActionAttributt aksjon);
+    void sjekkAtAnsattHarTilgangTilSak(String saksnummer, BeskyttetRessursActionAttributt aksjon);
 
     /**
      * Sjekker at det er et systembruker som står bak kallet.

--- a/src/main/java/no/nav/familie/inntektsmelding/server/tilgangsstyring/TilgangTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/server/tilgangsstyring/TilgangTjeneste.java
@@ -98,7 +98,7 @@ public class TilgangTjeneste implements Tilgang {
     }
 
     @Override
-    public void sjekkAtSaksbehandlerHarTilgangTilSak(String saksnummer, BeskyttetRessursActionAttributt aksjon) {
+    public void sjekkAtAnsattHarTilgangTilSak(String saksnummer, BeskyttetRessursActionAttributt aksjon) {
         var tilgang = sifAbacPdpKlient.harAnsattTilgangTilSak(saksnummer, aksjon);
         if (tilgang.isPresent()) {
             if (tilgang.get().tilgangsbeslutning().harTilgang()) {


### PR DESCRIPTION
### Behov / Bakgrunn
Det hender at saksbehandler melder inn at arbeidsgiver ikke finner en forespørsler. Vi har derfor behov for å finne ut av hvilke forespørsler som har blitt opprettet for et saksnummer.

### Løsning
Legger til nytt forvaltningsendepunkt for å hente forespørsler for saksnummer. Endepunktet krever drift-rollen 

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
