### PR TITLE
Fiks validering av saksnummer i nytt forvaltningsendepunkt

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forvaltning/OppgaverForvaltningRestTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forvaltning/OppgaverForvaltningRestTjeneste.java
@@ -128,7 +128,7 @@ public class OppgaverForvaltningRestTjeneste {
     })
     @Tilgangskontrollert
     public Response hentForespørslerForSak(
-        @Parameter(description = "Saksnummer det skal hentes forespørsler for") @Valid @NotNull @Pattern(regexp = SaksnummerDto.REGEXP) @Size(max = 19) @QueryParam("saksnummer") String saksnummer) {
+        @Parameter(description = "Saksnummer det skal hentes forespørsler for") @Valid @NotNull @Pattern(regexp = "^[a-zA-Z0-9æøåÆØÅ]+$") @Size(max = 19) @QueryParam("saksnummer") String saksnummer) {
         LOG.info("Henter forespørsler for saksnummer {}", saksnummer);
 
         sjekkAtKallerHarRollenDriftOgTilgangTilSak(saksnummer);


### PR DESCRIPTION
### Behov / Bakgrunn
Swagger får ikke til å validere reqexp-en vi bruker i SaksnummerDto. Det er mest sannsynlig fordi Swagger (javascript) ikke støtter den måten å skrive regexp på. 

### Løsning
Bytter til ny, tilsvarende regexp

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
