### PR TITLE
TSFF-2811: Nytt endepunkt for henting av inntektsmeldinger for et år med POST

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/HentInntektsmeldingerForÅrRequest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/HentInntektsmeldingerForÅrRequest.java
@@ -8,6 +8,5 @@ import no.nav.familie.inntektsmelding.typer.dto.ArbeidsgiverDto;
 
 public record HentInntektsmeldingerForÅrRequest(@NotNull @Valid AktørIdDto aktørId,
                                                 @NotNull @Valid ArbeidsgiverDto arbeidsgiverIdent,
-                                                @NotNull int år) {
+                                                @NotNull Integer år) {
 }
-

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/HentInntektsmeldingerForÅrRequest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/HentInntektsmeldingerForÅrRequest.java
@@ -1,0 +1,13 @@
+package no.nav.familie.inntektsmelding.imdialog.rest;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+import no.nav.familie.inntektsmelding.typer.dto.AktørIdDto;
+import no.nav.familie.inntektsmelding.typer.dto.ArbeidsgiverDto;
+
+public record HentInntektsmeldingerForÅrRequest(@NotNull @Valid AktørIdDto aktørId,
+                                                @NotNull @Valid ArbeidsgiverDto arbeidsgiverIdent,
+                                                @NotNull int år) {
+}
+

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/InntektsmeldingDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/InntektsmeldingDialogRest.java
@@ -94,6 +94,10 @@ public class InntektsmeldingDialogRest {
         return Response.ok(dto).build();
     }
 
+    /**
+     * @deprecated Bruk {@link #hentInntektsmeldingerForÅrPost(HentInntektsmeldingerForÅrRequest)} i stedet.
+     */
+    @Deprecated(forRemoval = true)
     @GET
     @Path(HENT_INNTEKTSMELDINGER_FOR_ÅR)
     @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
@@ -106,10 +110,26 @@ public class InntektsmeldingDialogRest {
 
         LOG.info("Henter inntektsmeldinger for år for organisasjon {}", arbeidsgiverIdent);
 
-        // denne metoden vil kun bli brukt for omsorgspenger da de har fagsak som strekker seg over ett år
         var dto = inntektsmeldingTjeneste.hentInntektsmeldingerForÅr(new AktørIdEntitet(aktorId),
             arbeidsgiverIdent,
             år,
+            Ytelsetype.OMSORGSPENGER);
+        return Response.ok(dto).build();
+    }
+
+    @POST
+    @Path(HENT_INNTEKTSMELDINGER_FOR_ÅR)
+    @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
+    @Tilgangskontrollert
+    public Response hentInntektsmeldingerForÅrPost(@NotNull @Valid HentInntektsmeldingerForÅrRequest request) {
+        tilgang.sjekkAtArbeidsgiverHarTilgangTilBedrift(new OrganisasjonsnummerDto(request.arbeidsgiverIdent().ident()));
+
+        LOG.info("Henter inntektsmeldinger for år for organisasjon {}", request.arbeidsgiverIdent());
+
+        // denne metoden vil kun bli brukt for omsorgspenger da de har fagsak som strekker seg over ett år
+        var dto = inntektsmeldingTjeneste.hentInntektsmeldingerForÅr(new AktørIdEntitet(request.aktørId().id()),
+            request.arbeidsgiverIdent().ident(),
+            request.år(),
             Ytelsetype.OMSORGSPENGER);
         return Response.ok(dto).build();
     }

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/InntektsmeldingDialogRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/rest/InntektsmeldingDialogRest.java
@@ -1,5 +1,6 @@
 package no.nav.familie.inntektsmelding.imdialog.rest;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -122,6 +123,10 @@ public class InntektsmeldingDialogRest {
     @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
     @Tilgangskontrollert
     public Response hentInntektsmeldingerForÅrPost(@NotNull @Valid HentInntektsmeldingerForÅrRequest request) {
+        if (request.år() > LocalDate.now().getYear() || request.år() < 2020) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Fremtidige år er ikke tillatt").build();
+        }
+
         tilgang.sjekkAtArbeidsgiverHarTilgangTilBedrift(new OrganisasjonsnummerDto(request.arbeidsgiverIdent().ident()));
 
         LOG.info("Henter inntektsmeldinger for år for organisasjon {}", request.arbeidsgiverIdent());


### PR DESCRIPTION
### Behov / Bakgrunn
Vi skal ikke ha både aktørId og orgnummer i url-en.

jira: https://nav.atlassian.net/browse/TSFF-2811

### Løsning
Oppretter et nytt endepunkt for samme funksjonalitet, bare med post.

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
