### PR TITLE
TSFF-2768: Lag kvittering til min side arbeidsgiver ved første innsending

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -454,7 +454,7 @@ public class ForespørselBehandlingTjeneste {
         // Oppdater status i arbeidsgiverportalen
         if (inntektsmeldingUuid.isPresent()) {
             var merkelapp = ForespørselTekster.finnMerkelapp(forespørsel.getYtelseType());
-            var beskjedTekst = ForespørselTekster.lagBeskjedOmOppdatertInntektsmelding();
+            var beskjedTekst = ForespørselTekster.lagBeskjedOmKvitteringFørsteInnsendingTekst();
             var hentInntektsmeldingPdfUrl = arbeidsgiverportalSkjemaLenke + "/server/api" + PdfDokumentRest.INNTEKTSMELDING_FULL_PATH + "/" + inntektsmeldingUuid.get();
             minSideArbeidsgiverTjeneste.sendNyBeskjedMedKvittering(forespørsel.getUuid().toString(),
                 merkelapp,

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -120,6 +120,17 @@ public class ForespørselBehandlingTjeneste {
         minSideArbeidsgiverTjeneste.oppdaterSakTilleggsinformasjon(forespørsel.getArbeidsgiverNotifikasjonSakId(), tilleggsinformasjon);
         forespørselTjeneste.ferdigstillForespørsel(forespørsel.getArbeidsgiverNotifikasjonSakId()); // Oppdaterer status i forespørsel
 
+        if (inntektsmeldingEntitet.isPresent()) {
+            var merkelapp = ForespørselTekster.finnMerkelapp(forespørsel.getYtelseType());
+            var beskjedTekst = ForespørselTekster.lagBeskjedOmOppdatertInntektsmelding();
+            var hentInntektsmeldingPdfUrl = arbeidsgiverportalSkjemaLenke + "/server/api" + PdfDokumentRest.INNTEKTSMELDING_FULL_PATH + "/" + inntektsmeldingEntitet.get().getUuid();
+            minSideArbeidsgiverTjeneste.sendNyBeskjedMedKvittering(forespørsel.getUuid().toString(),
+                merkelapp,
+                organisasjonsnummerDto.orgnr(),
+                beskjedTekst,
+                URI.create(hentInntektsmeldingPdfUrl));
+        }
+
         // Oppdaterer status i altinn dialogporten
         if (forespørsel.getDialogportenUuid().isPresent()) {
             if (dialogportenEnabled) {

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -122,7 +122,7 @@ public class ForespørselBehandlingTjeneste {
 
         if (inntektsmeldingEntitet.isPresent()) {
             var merkelapp = ForespørselTekster.finnMerkelapp(forespørsel.getYtelseType());
-            var beskjedTekst = ForespørselTekster.lagBeskjedOmOppdatertInntektsmelding();
+            var beskjedTekst = ForespørselTekster.lagBeskjedOmKvitteringFørsteInnsendingTekst();
             var hentInntektsmeldingPdfUrl = arbeidsgiverportalSkjemaLenke + "/server/api" + PdfDokumentRest.INNTEKTSMELDING_FULL_PATH + "/" + inntektsmeldingEntitet.get().getUuid();
             minSideArbeidsgiverTjeneste.sendNyBeskjedMedKvittering(forespørsel.getUuid().toString(),
                 merkelapp,
@@ -454,7 +454,7 @@ public class ForespørselBehandlingTjeneste {
         // Oppdater status i arbeidsgiverportalen
         if (inntektsmeldingUuid.isPresent()) {
             var merkelapp = ForespørselTekster.finnMerkelapp(forespørsel.getYtelseType());
-            var beskjedTekst = ForespørselTekster.lagBeskjedOmKvitteringFørsteInnsendingTekst();
+            var beskjedTekst = ForespørselTekster.lagBeskjedOmOppdatertInntektsmelding();
             var hentInntektsmeldingPdfUrl = arbeidsgiverportalSkjemaLenke + "/server/api" + PdfDokumentRest.INNTEKTSMELDING_FULL_PATH + "/" + inntektsmeldingUuid.get();
             minSideArbeidsgiverTjeneste.sendNyBeskjedMedKvittering(forespørsel.getUuid().toString(),
                 merkelapp,

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTekster.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTekster.java
@@ -36,6 +36,7 @@ public class ForespørselTekster {
     private static final String TILLEGGSINFORMASJON_FOR_FRAVÆRSDAG = "For fraværsdag %s";
     private static final String TILLEGGSINFORMASJON_FOR_FRAVÆRSPERIODE = "For fraværsperiode %s–%s";
 
+    private static final String BESKJED_OM_INNSENDT_INNTEKTSMELDING = "Innsendt inntektsmelding";
     private static final String BESKJED_OM_OPPDATERT_INNTEKTSMELDING = "Oppdatert inntektsmelding";
 
     private static final Logger LOG = LoggerFactory.getLogger(ForespørselTekster.class);
@@ -180,6 +181,10 @@ public class ForespørselTekster {
             case PLEIEPENGER_NÆRSTÅENDE -> "pleiepenger i livets sluttfase";
             case OPPLÆRINGSPENGER -> "opplæringspenger";
         };
+    }
+
+    public static String lagBeskjedOmKvitteringFørsteInnsendingTekst() {
+        return BESKJED_OM_INNSENDT_INNTEKTSMELDING;
     }
 
     public static String lagBeskjedOmOppdatertInntektsmelding() {


### PR DESCRIPTION
### Behov / Bakgrunn
Vi må opprette kvittering på min side arbeidsgiver, også ved første innsending. Per nå gjør vi det kun ved oppdatering, noe som kom på plass ved integreringen mot dialogporten.

Jira: https://nav.atlassian.net/browse/TSFF-2768

### Løsning
Legger til oppdatering med kvittering hivs det har blitt send inn en inntektsmelding (en forespørsel kan ferdigstilles uten at det har blitt sendt inn en IM)

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
