### PR TITLE
Returnerer ansettelsesperiode i oppslag for OMP

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjeneste.java
@@ -205,7 +205,7 @@ public class GrunnlagTjeneste {
     }
 
     public Optional<HentArbeidsforholdResponse> finnArbeidsforholdForFnr(PersonInfo personInfo, LocalDate førsteFraværsdag) {
-        var arbeidsforholdBrukerHarTilgangTil = arbeidstakerTjeneste.finnArbeidsforholdInnsenderHarTilgangTil(personInfo.fødselsnummer(), førsteFraværsdag);
+        var arbeidsforholdBrukerHarTilgangTil = arbeidstakerTjeneste.finnArbeidsforholdInnsenderHarTilgangTil(personInfo.fødselsnummer(), førsteFraværsdag, førsteFraværsdag);
         if (arbeidsforholdBrukerHarTilgangTil.isEmpty()) {
             return Optional.empty();
         }
@@ -244,7 +244,7 @@ public class GrunnlagTjeneste {
     }
 
     public boolean finnesOrgnummerIAaregPåPerson(PersonIdent personIdent, String organisasjonsnummer, LocalDate førsteFraværsdag) {
-        return arbeidsforholdTjeneste.hentArbeidsforhold(personIdent, førsteFraværsdag).stream()
+        return arbeidsforholdTjeneste.hentArbeidsforhold(personIdent, førsteFraværsdag, førsteFraværsdag).stream()
             .filter(arbeidsforhold -> arbeidsforhold.organisasjonsnummer().equals(organisasjonsnummer))
             .anyMatch(arbeidsforhold -> inkludererDato(førsteFraværsdag,
                 arbeidsforhold.ansettelsesperiode().fom(),

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/aareg/AaregRestKlient.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/aareg/AaregRestKlient.java
@@ -45,9 +45,9 @@ public class AaregRestKlient {
         this.restConfig = RestConfig.forClient(this.getClass());
     }
 
-    public List<ArbeidsforholdDto> finnArbeidsforholdForArbeidstaker(String personIdent, LocalDate førsteFraværsdag) {
+    public List<ArbeidsforholdDto> finnArbeidsforholdForArbeidstaker(String personIdent, LocalDate fom, LocalDate tom) {
         try {
-            var uri = lagUriForForFinnArbeidsforholdForArbeidstaker(førsteFraværsdag, førsteFraværsdag);
+            var uri = lagUriForForFinnArbeidsforholdForArbeidstaker(fom, tom);
             var request = RestRequest.newGET(uri, restConfig).header(NavHeaders.HEADER_NAV_PERSONIDENT, personIdent);
             var response = restClient.sendReturnUnhandled(request);
 

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRest.java
@@ -59,7 +59,7 @@ public class RefusjonOmsorgsdagerRest {
         @NotNull @Valid
         SlåOppArbeidstakerRequest request
     ) {
-        var response = refusjonOmsorgsdagerService.hentArbeidstaker(request.fødselsnummer());
+        var response = refusjonOmsorgsdagerService.hentArbeidstaker(request.fødselsnummer(), request.årstall());
 
         return Response.ok(response).build();
     }

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRest.java
@@ -59,8 +59,10 @@ public class RefusjonOmsorgsdagerRest {
         @NotNull @Valid
         SlåOppArbeidstakerRequest request
     ) {
+        if (request.årstall() != null && (request.årstall() < 2020 || request.årstall() > LocalDate.now().getYear())) {
+            return Response.status(Response.Status.BAD_REQUEST.getStatusCode(), "Årstall må være tidligst 2020 og senest dagens år").build();
+        }
         var response = refusjonOmsorgsdagerService.hentArbeidstaker(request.fødselsnummer(), request.årstall());
-
         return Response.ok(response).build();
     }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/SlåOppArbeidstakerRequest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/SlåOppArbeidstakerRequest.java
@@ -1,12 +1,11 @@
 package no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 
-public record SlåOppArbeidstakerRequest(@Valid @NotNull PersonIdent fødselsnummer, @Valid @NotNull Ytelsetype ytelseType, @Valid @Min(2020) Integer årstall) {
+public record SlåOppArbeidstakerRequest(@Valid @NotNull PersonIdent fødselsnummer, @Valid @NotNull Ytelsetype ytelseType, Integer årstall) {
 }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/SlåOppArbeidstakerRequest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/SlåOppArbeidstakerRequest.java
@@ -6,6 +6,6 @@ import jakarta.validation.constraints.NotNull;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 
-public record SlåOppArbeidstakerRequest(@Valid @NotNull PersonIdent fødselsnummer, @Valid @NotNull Ytelsetype ytelseType) {
+public record SlåOppArbeidstakerRequest(@Valid @NotNull PersonIdent fødselsnummer, @Valid @NotNull Ytelsetype ytelseType, Integer årstall) {
 }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/SlåOppArbeidstakerRequest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/SlåOppArbeidstakerRequest.java
@@ -1,11 +1,12 @@
 package no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 
-public record SlåOppArbeidstakerRequest(@Valid @NotNull PersonIdent fødselsnummer, @Valid @NotNull Ytelsetype ytelseType, Integer årstall) {
+public record SlåOppArbeidstakerRequest(@Valid @NotNull PersonIdent fødselsnummer, @Valid @NotNull Ytelsetype ytelseType, @Valid @Min(2020) Integer årstall) {
 }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/SlåOppArbeidstakerResponse.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/SlåOppArbeidstakerResponse.java
@@ -2,6 +2,8 @@ package no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest;
 
 import java.util.List;
 
+import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
+
 public record SlåOppArbeidstakerResponse(Personinformasjon personinformasjon, List<ArbeidsforholdDto> arbeidsforhold) {
     public record Personinformasjon(
         String fornavn,
@@ -10,6 +12,6 @@ public record SlåOppArbeidstakerResponse(Personinformasjon personinformasjon, L
         String fødselsnummer,
         String aktørId) {
     }
-    public record ArbeidsforholdDto(String organisasjonsnummer, String organisasjonsnavn) {
+    public record ArbeidsforholdDto(String organisasjonsnummer, String organisasjonsnavn, PeriodeDto ansettelsesperiode) {
     }
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/ArbeidsforholdTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/ArbeidsforholdTjeneste.java
@@ -30,8 +30,8 @@ public class ArbeidsforholdTjeneste {
         this.aaregRestKlient = aaregRestKlient;
     }
 
-    public List<ArbeidsforholdDto> hentArbeidsforhold(PersonIdent ident, LocalDate førsteFraværsdag) {
-        var aaregInfo = aaregRestKlient.finnArbeidsforholdForArbeidstaker(ident.getIdent(), førsteFraværsdag);
+    public List<ArbeidsforholdDto> hentArbeidsforhold(PersonIdent ident, LocalDate fom, LocalDate tom) {
+        var aaregInfo = aaregRestKlient.finnArbeidsforholdForArbeidstaker(ident.getIdent(), fom, tom);
         if (aaregInfo == null) {
             LOG.info("Fant ingen arbeidsforhold for ident {}. Returnerer tom liste", ident.getIdent());
             return Collections.emptyList();

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/ArbeidstakerTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/ArbeidstakerTjeneste.java
@@ -31,8 +31,8 @@ public class ArbeidstakerTjeneste {
         this.altinnTilgangTjeneste = altinnTilgangTjeneste;
     }
 
-    public List<ArbeidsforholdDto> finnArbeidsforholdInnsenderHarTilgangTil(PersonIdent ident, LocalDate førsteFraværsdag) {
-        var alleArbeidsforhold = arbeidsforholdTjeneste.hentArbeidsforhold(ident, førsteFraværsdag);
+    public List<ArbeidsforholdDto> finnArbeidsforholdInnsenderHarTilgangTil(PersonIdent ident, LocalDate fom, LocalDate tom) {
+        var alleArbeidsforhold = arbeidsforholdTjeneste.hentArbeidsforhold(ident, fom, tom);
         LOG.info("Fant {} arbeidsforhold i Aa-registeret for {}", alleArbeidsforhold.size(), ident);
 
         if (alleArbeidsforhold.isEmpty()) {

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerService.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerService.java
@@ -21,6 +21,7 @@ import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.ArbeidsforholdDt
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.HentInnloggetBrukerResponse;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.HentInntektsopplysningerResponse;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.SlåOppArbeidstakerResponse;
+import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
 import no.nav.vedtak.exception.FunksjonellException;
 
 @ApplicationScoped
@@ -49,7 +50,7 @@ public class RefusjonOmsorgsdagerService {
         // CDI
     }
 
-    public SlåOppArbeidstakerResponse hentArbeidstaker(PersonIdent fødselsnummer) {
+    public SlåOppArbeidstakerResponse hentArbeidstaker(PersonIdent fødselsnummer, Integer årstall) {
         LOG.info("Slår opp arbeidstaker");
         var personInfo = personTjeneste.hentPersonFraIdent(fødselsnummer);
 
@@ -57,12 +58,18 @@ public class RefusjonOmsorgsdagerService {
             throw new FunksjonellException("PERSON_IKKE_FUNNET", "Fant ikke person i pdl", null, null);
         }
 
-        var alleArbeidsforhold = arbeidstakerTjeneste.finnArbeidsforholdInnsenderHarTilgangTil(fødselsnummer, LocalDate.now());
+        LocalDate fom = årstall != null ? LocalDate.of(årstall, 1, 1) : LocalDate.now();
+        LocalDate tom = årstall != null ? LocalDate.of(årstall, 12, 31) : LocalDate.now();
+        if (tom.isAfter(LocalDate.now())) {
+            tom = LocalDate.now();
+        }
+        var alleArbeidsforhold = arbeidstakerTjeneste.finnArbeidsforholdInnsenderHarTilgangTil(fødselsnummer, fom, tom);
         var unikeArbeidsforhold = filtrerUnikeArbeidsforhold(alleArbeidsforhold);
         var arbeidsforholdMedOrgnavn = unikeArbeidsforhold.stream()
             .map(arbeidsforhold -> new SlåOppArbeidstakerResponse.ArbeidsforholdDto(
                 arbeidsforhold.organisasjonsnummer(),
-                organisasjonTjeneste.finnOrganisasjon(arbeidsforhold.organisasjonsnummer()).navn()
+                organisasjonTjeneste.finnOrganisasjon(arbeidsforhold.organisasjonsnummer()).navn(),
+                new PeriodeDto(arbeidsforhold.ansettelsesperiode().fom(), arbeidsforhold.ansettelsesperiode().tom())
             ))
             .toList();
 

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerService.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerService.java
@@ -58,6 +58,9 @@ public class RefusjonOmsorgsdagerService {
             throw new FunksjonellException("PERSON_IKKE_FUNNET", "Fant ikke person i pdl", null, null);
         }
 
+        if (årstall != null && årstall > LocalDate.now().getYear()) {
+            throw new IllegalArgumentException("Kan ikke bruke fremtidig årstall i søk");
+        }
         LocalDate fom = årstall != null ? LocalDate.of(årstall, 1, 1) : LocalDate.now();
         LocalDate tom = årstall != null ? LocalDate.of(årstall, 12, 31) : LocalDate.now();
         if (tom.isAfter(LocalDate.now())) {

--- a/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagTjenesteTest.java
@@ -212,7 +212,7 @@ class GrunnlagTjenesteTest {
         var ansettelsesperiode = new ArbeidsforholdDto.Ansettelsesperiode(LocalDate.now(), LocalDate.now().plusMonths(2));
         var personInfo = new PersonInfo("Navn", null, "Navnesen", fnr, aktørId, LocalDate.now(), null, Kjønn.KVINNE);
 
-        when(arbeidstakerTjeneste.finnArbeidsforholdInnsenderHarTilgangTil(fnr, førsteFraværsdag)).thenReturn(List.of(new ArbeidsforholdDto(orgnr, ansettelsesperiode)));
+        when(arbeidstakerTjeneste.finnArbeidsforholdInnsenderHarTilgangTil(fnr, førsteFraværsdag, førsteFraværsdag)).thenReturn(List.of(new ArbeidsforholdDto(orgnr, ansettelsesperiode)));
         when(organisasjonTjeneste.finnOrganisasjon(orgnr)).thenReturn(new Organisasjon("Bedriften", orgnr));
 
         // Act

--- a/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/aareg/AaregRestKlientTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/integrasjoner/aareg/AaregRestKlientTest.java
@@ -59,7 +59,7 @@ class AaregRestKlientTest {
         when(restClient.sendReturnUnhandled(any(RestRequest.class)))
             .thenReturn(httpResponse);
 
-        var result = aaregRestKlient.finnArbeidsforholdForArbeidstaker(ident, LocalDate.now());
+        var result = aaregRestKlient.finnArbeidsforholdForArbeidstaker(ident, LocalDate.now(), LocalDate.now());
 
         assertThat(result).hasSize(1);
         assertThat(result.getFirst()).isEqualTo(arbeidsforhold);
@@ -80,7 +80,7 @@ class AaregRestKlientTest {
 
         // Act & Assert
         var exception = assertThrows(IllegalArgumentException.class,
-            () -> aaregRestKlient.finnArbeidsforholdForArbeidstaker(ident, LocalDate.now()));
+            () -> aaregRestKlient.finnArbeidsforholdForArbeidstaker(ident, LocalDate.now(), LocalDate.now()));
 
         assertThat(exception.getMessage())
             .isEqualTo("Utviklerfeil syntax-exception for finnArbeidsforholdForArbeidstaker");
@@ -99,7 +99,7 @@ class AaregRestKlientTest {
             .thenReturn(httpResponse);
 
         // Act
-        var result = aaregRestKlient.finnArbeidsforholdForArbeidstaker(ident, LocalDate.now());
+        var result = aaregRestKlient.finnArbeidsforholdForArbeidstaker(ident, LocalDate.now(), LocalDate.now());
 
         // Assert
         assertThat(result).isEmpty();
@@ -114,7 +114,7 @@ class AaregRestKlientTest {
             .thenThrow(new IntegrasjonException("K9-12345", "404 feil"));
 
         // Act
-        var result = aaregRestKlient.finnArbeidsforholdForArbeidstaker(ident, LocalDate.now());
+        var result = aaregRestKlient.finnArbeidsforholdForArbeidstaker(ident, LocalDate.now(), LocalDate.now());
 
         // Assert
         assertThat(result).isEmpty();
@@ -128,7 +128,7 @@ class AaregRestKlientTest {
         when(restClient.sendReturnUnhandled(any(RestRequest.class)))
             .thenThrow(new IntegrasjonException("K9-w00t", "Ukjent feil"));
 
-        assertThrows(IntegrasjonException.class, () -> aaregRestKlient.finnArbeidsforholdForArbeidstaker(ident, LocalDate.now()));
+        assertThrows(IntegrasjonException.class, () -> aaregRestKlient.finnArbeidsforholdForArbeidstaker(ident, LocalDate.now(), LocalDate.now()));
     }
 
     @Test

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRestTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRestTest.java
@@ -22,6 +22,7 @@ import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.tjenester.RefusjonOmsorgsdagerService;
 import no.nav.familie.inntektsmelding.typer.dto.MånedslønnStatus;
+import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
 import no.nav.vedtak.exception.FunksjonellException;
 
 @ExtendWith(MockitoExtension.class)
@@ -40,11 +41,11 @@ class RefusjonOmsorgsdagerRestTest {
     @Test
     void slå_opp_arbeidstaker_skal_returnere_ok_response_når_arbeidstaker_finnes() {
         var fnr = PersonIdent.fra("12345678910");
-        var request = new SlåOppArbeidstakerRequest(fnr, Ytelsetype.OMSORGSPENGER);
-        var arbeidsforhold = List.of(new SlåOppArbeidstakerResponse.ArbeidsforholdDto("999999999", "Arbeidsgiver AS"));
+        var request = new SlåOppArbeidstakerRequest(fnr, Ytelsetype.OMSORGSPENGER, LocalDate.now().getYear());
+        var arbeidsforhold = List.of(new SlåOppArbeidstakerResponse.ArbeidsforholdDto("999999999", "Arbeidsgiver AS", new PeriodeDto(LocalDate.now(), LocalDate.now())));
         var arbeidstakerInfo = new SlåOppArbeidstakerResponse(new SlåOppArbeidstakerResponse.Personinformasjon("fornavn", "mellomnavn", "etternavn", "23500180528", "12345"), arbeidsforhold);
 
-        when(refusjonOmsorgsdagerServiceMock.hentArbeidstaker(fnr)).thenReturn(arbeidstakerInfo);
+        when(refusjonOmsorgsdagerServiceMock.hentArbeidstaker(fnr, LocalDate.now().getYear())).thenReturn(arbeidstakerInfo);
 
         var response = rest.slåOppArbeidstaker(request);
 
@@ -55,9 +56,9 @@ class RefusjonOmsorgsdagerRestTest {
     @Test
     void slå_opp_arbeidstaker_kaster_PERSON_IKKE_FUNNET_når_arbeidstaker_ikke_finnes() {
         var fnr = PersonIdent.fra("12345678910");
-        var request = new SlåOppArbeidstakerRequest(fnr, Ytelsetype.OMSORGSPENGER);
+        var request = new SlåOppArbeidstakerRequest(fnr, Ytelsetype.OMSORGSPENGER, LocalDate.now().getYear());
 
-        when(refusjonOmsorgsdagerServiceMock.hentArbeidstaker(fnr))
+        when(refusjonOmsorgsdagerServiceMock.hentArbeidstaker(fnr, LocalDate.now().getYear()))
             .thenThrow(new FunksjonellException("PERSON_IKKE_FUNNET", "Fant ikke person i pdl", null));
 
         var ex = assertThrows(FunksjonellException.class, () -> rest.slåOppArbeidstaker(request));

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/ArbeidsforholdTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/ArbeidsforholdTjenesteTest.java
@@ -36,10 +36,10 @@ class ArbeidsforholdTjenesteTest {
     @Test
     void skalReturnereTomListeNårAaregReturnerNull() {
         var nå = LocalDate.now();
-        when(aaregRestKlient.finnArbeidsforholdForArbeidstaker(PERSON_IDENT.getIdent(), nå))
+        when(aaregRestKlient.finnArbeidsforholdForArbeidstaker(PERSON_IDENT.getIdent(), nå, nå))
             .thenReturn(null);
 
-        var resultat = arbeidsforholdTjeneste.hentArbeidsforhold(PERSON_IDENT, nå);
+        var resultat = arbeidsforholdTjeneste.hentArbeidsforhold(PERSON_IDENT, nå, nå);
 
         assertThat(resultat).isEmpty();
     }
@@ -47,10 +47,10 @@ class ArbeidsforholdTjenesteTest {
     @Test
     void skalReturnereTomListeNårAaregReturnerTomListe() {
         var nå = LocalDate.now();
-        when(aaregRestKlient.finnArbeidsforholdForArbeidstaker(PERSON_IDENT.getIdent(), nå))
+        when(aaregRestKlient.finnArbeidsforholdForArbeidstaker(PERSON_IDENT.getIdent(), nå, nå))
             .thenReturn(Collections.emptyList());
 
-        var resultat = arbeidsforholdTjeneste.hentArbeidsforhold(PERSON_IDENT, nå);
+        var resultat = arbeidsforholdTjeneste.hentArbeidsforhold(PERSON_IDENT, nå, nå);
 
         assertThat(resultat).isEmpty();
     }
@@ -74,10 +74,10 @@ class ArbeidsforholdTjenesteTest {
 
         var nå = LocalDate.now();
 
-        when(aaregRestKlient.finnArbeidsforholdForArbeidstaker(PERSON_IDENT.getIdent(), nå))
+        when(aaregRestKlient.finnArbeidsforholdForArbeidstaker(PERSON_IDENT.getIdent(), nå, nå))
             .thenReturn(List.of(arbeidsforhold));
 
-        var resultat = arbeidsforholdTjeneste.hentArbeidsforhold(PERSON_IDENT, nå);
+        var resultat = arbeidsforholdTjeneste.hentArbeidsforhold(PERSON_IDENT, nå, nå);
 
         assertThat(resultat)
             .hasSize(1)
@@ -121,10 +121,10 @@ class ArbeidsforholdTjenesteTest {
         var nå = LocalDate.now();
 
 
-        when(aaregRestKlient.finnArbeidsforholdForArbeidstaker(PERSON_IDENT.getIdent(), nå))
+        when(aaregRestKlient.finnArbeidsforholdForArbeidstaker(PERSON_IDENT.getIdent(), nå, nå))
             .thenReturn(List.of(arbeidsforhold1, arbeidsforhold2));
 
-        var resultat = arbeidsforholdTjeneste.hentArbeidsforhold(PERSON_IDENT, nå);
+        var resultat = arbeidsforholdTjeneste.hentArbeidsforhold(PERSON_IDENT, nå, nå);
 
         assertThat(resultat).hasSize(2);
 

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/ArbeidstakerTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/ArbeidstakerTjenesteTest.java
@@ -41,11 +41,11 @@ class ArbeidstakerTjenesteTest {
     void returnerer_arbeidstakerinfo_om_dette_finnes() {
         var førsteFraværsdag = LocalDate.now();
         var ansettelsesperiode = new ArbeidsforholdDto.Ansettelsesperiode(LocalDate.now(), LocalDate.now().plusMonths(2));
-        when(arbeidsforholdTjenesteMock.hentArbeidsforhold(any(), any()))
+        when(arbeidsforholdTjenesteMock.hentArbeidsforhold(any(), any(), any()))
             .thenReturn(List.of(new ArbeidsforholdDto("000000000", ansettelsesperiode)));
         when(altinnTilgangTjenesteMock.harTilgangTilBedriften(any())).thenReturn(true);
 
-        var resultat = arbeidstakerTjeneste.finnArbeidsforholdInnsenderHarTilgangTil(TILFELDIG_PERSON_IDENT, førsteFraværsdag);
+        var resultat = arbeidstakerTjeneste.finnArbeidsforholdInnsenderHarTilgangTil(TILFELDIG_PERSON_IDENT, førsteFraværsdag, førsteFraværsdag);
         assertThat(resultat).hasSize(1);
 
         var arbeidsforhold = resultat.getFirst();
@@ -56,11 +56,11 @@ class ArbeidstakerTjenesteTest {
     void verifiserer_arbeidsforhold_detaljer() {
         var førsteFraværsdag = LocalDate.now();
         var ansettelsesPeriode = new ArbeidsforholdDto.Ansettelsesperiode(LocalDate.now().minusYears(1), Tid.TIDENES_ENDE);
-        when(arbeidsforholdTjenesteMock.hentArbeidsforhold(any(), any()))
+        when(arbeidsforholdTjenesteMock.hentArbeidsforhold(any(), any(), any()))
             .thenReturn(List.of(new ArbeidsforholdDto("00000000", ansettelsesPeriode)));
         when(altinnTilgangTjenesteMock.harTilgangTilBedriften(any())).thenReturn(true);
 
-        var resultat = arbeidstakerTjeneste.finnArbeidsforholdInnsenderHarTilgangTil(TILFELDIG_PERSON_IDENT, førsteFraværsdag);
+        var resultat = arbeidstakerTjeneste.finnArbeidsforholdInnsenderHarTilgangTil(TILFELDIG_PERSON_IDENT, førsteFraværsdag, førsteFraværsdag);
 
         assertThat(resultat).hasSize(1);
         var arbeidsforhold = resultat.getFirst();
@@ -73,7 +73,7 @@ class ArbeidstakerTjenesteTest {
         var førsteFraværsdag = LocalDate.now();
         var ansettelsesPeriode = new ArbeidsforholdDto.Ansettelsesperiode(LocalDate.now().minusYears(1), Tid.TIDENES_ENDE);
         var ansettelsesPeriode2 = new ArbeidsforholdDto.Ansettelsesperiode(LocalDate.now().minusYears(1), LocalDate.now().plusMonths(5));
-        when(arbeidsforholdTjenesteMock.hentArbeidsforhold(any(), any()))
+        when(arbeidsforholdTjenesteMock.hentArbeidsforhold(any(), any(), any()))
             .thenReturn(List.of(
                 new ArbeidsforholdDto("00000000", ansettelsesPeriode),
                 new ArbeidsforholdDto("00000001", ansettelsesPeriode2)));
@@ -81,7 +81,7 @@ class ArbeidstakerTjenesteTest {
         when(altinnTilgangTjenesteMock.harTilgangTilBedriften("00000000")).thenReturn(false);
         when(altinnTilgangTjenesteMock.harTilgangTilBedriften("00000001")).thenReturn(true);
 
-        var resultat = arbeidstakerTjeneste.finnArbeidsforholdInnsenderHarTilgangTil(TILFELDIG_PERSON_IDENT, førsteFraværsdag);
+        var resultat = arbeidstakerTjeneste.finnArbeidsforholdInnsenderHarTilgangTil(TILFELDIG_PERSON_IDENT, førsteFraværsdag, førsteFraværsdag);
 
         assertThat(resultat).hasSize(1);
         var arbeidsforhold = resultat.getFirst();

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerServiceTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerServiceTest.java
@@ -30,6 +30,7 @@ import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.HentInntektsoppl
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.InnloggetBrukerDto;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.SlåOppArbeidstakerResponse;
 import no.nav.familie.inntektsmelding.typer.dto.Kjønn;
+import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
 import no.nav.vedtak.exception.FunksjonellException;
 
@@ -73,16 +74,16 @@ class RefusjonOmsorgsdagerServiceTest {
 
         var forventetArbeidstakerInfo = new SlåOppArbeidstakerResponse(
             new SlåOppArbeidstakerResponse.Personinformasjon("fornavn", "mellomnavn", "etternavn", "12345678910", aktørId.getAktørId()),
-            List.of(new SlåOppArbeidstakerResponse.ArbeidsforholdDto(orgnummer, "Arbeidsgiver AS")));
+            List.of(new SlåOppArbeidstakerResponse.ArbeidsforholdDto(orgnummer, "Arbeidsgiver AS", new PeriodeDto(ansettelsesperiode.fom(), ansettelsesperiode.tom()))));
 
         when(personTjenesteMock.hentPersonFraIdent(fødselsnummer)).thenReturn(new PersonInfo("fornavn", "mellomnavn", "etternavn", fødselsnummer, aktørId, LocalDate.now(), null, Kjønn.KVINNE));
-        when(arbeidstakerTjenesteMock.finnArbeidsforholdInnsenderHarTilgangTil(fødselsnummer, førsteFraværsdag)).thenReturn(arbeidsforhold);
+        when(arbeidstakerTjenesteMock.finnArbeidsforholdInnsenderHarTilgangTil(fødselsnummer, LocalDate.of(førsteFraværsdag.getYear(), 1, 1), LocalDate.now())).thenReturn(arbeidsforhold);
         when(organisasjonTjenesteMock.finnOrganisasjon(orgnummer)).thenReturn(new Organisasjon( "Arbeidsgiver AS", orgnummer));
 
-        var response = service.hentArbeidstaker(fødselsnummer);
+        var response = service.hentArbeidstaker(fødselsnummer, førsteFraværsdag.getYear());
 
         assertEquals(forventetArbeidstakerInfo, response);
-        verify(arbeidstakerTjenesteMock).finnArbeidsforholdInnsenderHarTilgangTil(fødselsnummer, førsteFraværsdag);
+        verify(arbeidstakerTjenesteMock).finnArbeidsforholdInnsenderHarTilgangTil(fødselsnummer, LocalDate.of(førsteFraværsdag.getYear(), 1, 1), LocalDate.now());
     }
 
     @Test
@@ -91,7 +92,7 @@ class RefusjonOmsorgsdagerServiceTest {
 
         when(personTjenesteMock.hentPersonFraIdent(fødselsnummer)).thenReturn(null);
 
-        var ex = assertThrows(FunksjonellException.class, () -> service.hentArbeidstaker(fødselsnummer));
+        var ex = assertThrows(FunksjonellException.class, () -> service.hentArbeidstaker(fødselsnummer, LocalDate.now().getYear()));
 
         assertThat(ex.getMessage()).contains("PERSON_IKKE_FUNNET");
         verifyNoInteractions(arbeidstakerTjenesteMock);
@@ -104,10 +105,10 @@ class RefusjonOmsorgsdagerServiceTest {
 
         when(personTjenesteMock.hentPersonFraIdent(fødselsnummer)).thenReturn(
             new PersonInfo("fornavn", "mellomnavn", "etternavn", fødselsnummer, aktørId, LocalDate.now(), null, Kjønn.KVINNE));
-        when(arbeidstakerTjenesteMock.finnArbeidsforholdInnsenderHarTilgangTil(fødselsnummer, LocalDate.now()))
+        when(arbeidstakerTjenesteMock.finnArbeidsforholdInnsenderHarTilgangTil(fødselsnummer, LocalDate.of(LocalDate.now().getYear(), 1, 1), LocalDate.now()))
             .thenReturn(List.of());
 
-        var ex = assertThrows(FunksjonellException.class, () -> service.hentArbeidstaker(fødselsnummer));
+        var ex = assertThrows(FunksjonellException.class, () -> service.hentArbeidstaker(fødselsnummer, LocalDate.now().getYear()));
 
         assertThat(ex.getMessage()).contains("INGEN_ARBEIDSFORHOLD");
     }


### PR DESCRIPTION
### Behov / Bakgrunn
Se https://nav-it.slack.com/archives/C0828DBU5K3/p1782811952543269
Har behov for å kunne sende inn refusjonskrav på avsluttede arbeidsforhold.

### Løsning
Tar inn årstall som parameter for oppslag på arbeidstaker, og returnerer ansettelsesperioden for hvert arbeidsforhold.

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
