### PR TITLE
TSFF-1771: Rydder i logger og returnerer tom=null for aktive arbeidsforhold

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/SlåOppArbeidstakerResponse.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/SlåOppArbeidstakerResponse.java
@@ -1,8 +1,7 @@
 package no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest;
 
+import java.time.LocalDate;
 import java.util.List;
-
-import no.nav.familie.inntektsmelding.integrasjoner.aareg.dto.PeriodeDto;
 
 public record SlåOppArbeidstakerResponse(Personinformasjon personinformasjon, List<ArbeidsforholdDto> arbeidsforhold) {
     public record Personinformasjon(
@@ -12,6 +11,7 @@ public record SlåOppArbeidstakerResponse(Personinformasjon personinformasjon, L
         String fødselsnummer,
         String aktørId) {
     }
-    public record ArbeidsforholdDto(String organisasjonsnummer, String organisasjonsnavn, PeriodeDto ansettelsesperiode) {
+    public record ArbeidsforholdDto(String organisasjonsnummer, String organisasjonsnavn, Ansettelsesperiode ansettelsesperiode) {
     }
+    public record Ansettelsesperiode(LocalDate fom, LocalDate tom) {}
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/SlåOppArbeidstakerResponse.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/SlåOppArbeidstakerResponse.java
@@ -2,7 +2,7 @@ package no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest;
 
 import java.util.List;
 
-import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
+import no.nav.familie.inntektsmelding.integrasjoner.aareg.dto.PeriodeDto;
 
 public record SlåOppArbeidstakerResponse(Personinformasjon personinformasjon, List<ArbeidsforholdDto> arbeidsforhold) {
     public record Personinformasjon(

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/ArbeidsforholdTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/ArbeidsforholdTjeneste.java
@@ -14,7 +14,6 @@ import no.nav.familie.inntektsmelding.integrasjoner.aareg.AaregRestKlient;
 import no.nav.familie.inntektsmelding.integrasjoner.aareg.dto.OpplysningspliktigArbeidsgiverDto;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.ArbeidsforholdDto;
-import no.nav.foreldrepenger.konfig.Environment;
 import no.nav.vedtak.konfig.Tid;
 
 @ApplicationScoped
@@ -22,7 +21,7 @@ public class ArbeidsforholdTjeneste {
     private AaregRestKlient aaregRestKlient;
     private static final Logger LOG = LoggerFactory.getLogger(ArbeidsforholdTjeneste.class);
 
-    public ArbeidsforholdTjeneste() {
+    ArbeidsforholdTjeneste() {
         // CDI
     }
 
@@ -38,11 +37,8 @@ public class ArbeidsforholdTjeneste {
             return Collections.emptyList();
         }
         LOG.info("Fant {} arbeidsforhold for ident {} i tidsrommet [{}, {}].", aaregInfo.size(), ident, fom, tom);
-        if (Environment.current().isDev()) {
-            LOG.info("Respons fra aareg for ident {} i tidsrommet [{}, {}]: {}", ident, fom, tom, aaregInfo);
-        }
         return aaregInfo.stream()
-            .filter(arb -> OpplysningspliktigArbeidsgiverDto.Type.ORGANISASJON.equals(arb.arbeidsgiver().type())) // Vi skal aldri behandle private arbeidsforhold i ftinntektsmelding
+            .filter(arb -> OpplysningspliktigArbeidsgiverDto.Type.ORGANISASJON.equals(arb.arbeidsgiver().type())) // Vi skal aldri behandle private arbeidsforhold i k9-inntektsmelding
             .map(arbeidsforhold -> new ArbeidsforholdDto(
                 arbeidsforhold.arbeidsgiver().organisasjonsnummer(),
                 mapAnsettelsesperiode(arbeidsforhold)

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/ArbeidstakerTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/ArbeidstakerTjeneste.java
@@ -21,7 +21,7 @@ public class ArbeidstakerTjeneste {
     private ArbeidsforholdTjeneste arbeidsforholdTjeneste;
     private AltinnTilgangTjeneste altinnTilgangTjeneste;
 
-    public ArbeidstakerTjeneste() {
+    ArbeidstakerTjeneste() {
         // CDI
     }
 
@@ -33,10 +33,8 @@ public class ArbeidstakerTjeneste {
 
     public List<ArbeidsforholdDto> finnArbeidsforholdInnsenderHarTilgangTil(PersonIdent ident, LocalDate fom, LocalDate tom) {
         var alleArbeidsforhold = arbeidsforholdTjeneste.hentArbeidsforhold(ident, fom, tom);
-        LOG.info("Fant {} arbeidsforhold i Aa-registeret for {} i tidsrommet [{}, {}].", alleArbeidsforhold.size(), ident, fom, tom);
 
         if (alleArbeidsforhold.isEmpty()) {
-            LOG.info("Fant ingen arbeidsforhold i Aa-registeret for {} i tidsrommet [{}, {}]", ident, fom, tom);
             return Collections.emptyList();
         }
 
@@ -49,7 +47,7 @@ public class ArbeidstakerTjeneste {
             LOG.info("Innsender har tilgang til {} av {} arbeidsforhold for {}", arbeidsforholdInnsenderHarTilgangTil.size(), alleArbeidsforhold.size(), ident);
         }
 
-        LOG.info("Returnerer informasjon om arbeidsforhold for {}", ident);
+        LOG.info("Returnerer informasjon om {} arbeidsforhold for {}", arbeidsforholdInnsenderHarTilgangTil.size(), ident);
         return arbeidsforholdInnsenderHarTilgangTil;
     }
 

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerService.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerService.java
@@ -13,7 +13,6 @@ import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import no.nav.familie.inntektsmelding.integrasjoner.aareg.dto.PeriodeDto;
 import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.InntektTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.OrganisasjonTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
@@ -48,7 +47,7 @@ public class RefusjonOmsorgsdagerService {
         this.organisasjonTjeneste = organisasjonTjeneste;
     }
 
-    public RefusjonOmsorgsdagerService() {
+    RefusjonOmsorgsdagerService() {
         // CDI
     }
 
@@ -74,7 +73,7 @@ public class RefusjonOmsorgsdagerService {
             .map(arbeidsforhold -> new SlåOppArbeidstakerResponse.ArbeidsforholdDto(
                 arbeidsforhold.organisasjonsnummer(),
                 organisasjonTjeneste.finnOrganisasjon(arbeidsforhold.organisasjonsnummer()).navn(),
-                new PeriodeDto(arbeidsforhold.ansettelsesperiode().fom(),
+                new SlåOppArbeidstakerResponse.Ansettelsesperiode(arbeidsforhold.ansettelsesperiode().fom(),
                     Objects.equals(arbeidsforhold.ansettelsesperiode().tom(), Tid.TIDENES_ENDE) ? null : arbeidsforhold.ansettelsesperiode().tom()) // Returnerer tom = null for aktive arbeidsforhold
             ))
             .toList();

--- a/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerService.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerService.java
@@ -3,6 +3,7 @@ package no.nav.familie.inntektsmelding.refusjonomsorgsdager.tjenester;
 import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -12,6 +13,7 @@ import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import no.nav.familie.inntektsmelding.integrasjoner.aareg.dto.PeriodeDto;
 import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.InntektTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.OrganisasjonTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
@@ -21,8 +23,8 @@ import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.ArbeidsforholdDt
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.HentInnloggetBrukerResponse;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.HentInntektsopplysningerResponse;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.SlåOppArbeidstakerResponse;
-import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
 import no.nav.vedtak.exception.FunksjonellException;
+import no.nav.vedtak.konfig.Tid;
 
 @ApplicationScoped
 public class RefusjonOmsorgsdagerService {
@@ -72,7 +74,8 @@ public class RefusjonOmsorgsdagerService {
             .map(arbeidsforhold -> new SlåOppArbeidstakerResponse.ArbeidsforholdDto(
                 arbeidsforhold.organisasjonsnummer(),
                 organisasjonTjeneste.finnOrganisasjon(arbeidsforhold.organisasjonsnummer()).navn(),
-                new PeriodeDto(arbeidsforhold.ansettelsesperiode().fom(), arbeidsforhold.ansettelsesperiode().tom())
+                new PeriodeDto(arbeidsforhold.ansettelsesperiode().fom(),
+                    Objects.equals(arbeidsforhold.ansettelsesperiode().tom(), Tid.TIDENES_ENDE) ? null : arbeidsforhold.ansettelsesperiode().tom()) // Returnerer tom = null for aktive arbeidsforhold
             ))
             .toList();
 

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRestTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRestTest.java
@@ -18,11 +18,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import no.nav.familie.inntektsmelding.integrasjoner.aareg.dto.PeriodeDto;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.tjenester.RefusjonOmsorgsdagerService;
 import no.nav.familie.inntektsmelding.typer.dto.MånedslønnStatus;
-import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
 import no.nav.vedtak.exception.FunksjonellException;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRestTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/rest/RefusjonOmsorgsdagerRestTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import no.nav.familie.inntektsmelding.integrasjoner.aareg.dto.PeriodeDto;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.tjenester.RefusjonOmsorgsdagerService;
@@ -42,7 +41,7 @@ class RefusjonOmsorgsdagerRestTest {
     void slå_opp_arbeidstaker_skal_returnere_ok_response_når_arbeidstaker_finnes() {
         var fnr = PersonIdent.fra("12345678910");
         var request = new SlåOppArbeidstakerRequest(fnr, Ytelsetype.OMSORGSPENGER, LocalDate.now().getYear());
-        var arbeidsforhold = List.of(new SlåOppArbeidstakerResponse.ArbeidsforholdDto("999999999", "Arbeidsgiver AS", new PeriodeDto(LocalDate.now(), LocalDate.now())));
+        var arbeidsforhold = List.of(new SlåOppArbeidstakerResponse.ArbeidsforholdDto("999999999", "Arbeidsgiver AS", new SlåOppArbeidstakerResponse.Ansettelsesperiode(LocalDate.now(), LocalDate.now())));
         var arbeidstakerInfo = new SlåOppArbeidstakerResponse(new SlåOppArbeidstakerResponse.Personinformasjon("fornavn", "mellomnavn", "etternavn", "23500180528", "12345"), arbeidsforhold);
 
         when(refusjonOmsorgsdagerServiceMock.hentArbeidstaker(fnr, LocalDate.now().getYear())).thenReturn(arbeidstakerInfo);

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerServiceTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import no.nav.familie.inntektsmelding.integrasjoner.aareg.dto.PeriodeDto;
 import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.InntektTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.Inntektsopplysninger;
 import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.Organisasjon;
@@ -30,7 +31,6 @@ import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.HentInntektsoppl
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.InnloggetBrukerDto;
 import no.nav.familie.inntektsmelding.refusjonomsorgsdager.rest.SlåOppArbeidstakerResponse;
 import no.nav.familie.inntektsmelding.typer.dto.Kjønn;
-import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
 import no.nav.vedtak.exception.FunksjonellException;
 

--- a/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerServiceTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/refusjonomsorgsdager/tjenester/RefusjonOmsorgsdagerServiceTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import no.nav.familie.inntektsmelding.integrasjoner.aareg.dto.PeriodeDto;
 import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.InntektTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.Inntektsopplysninger;
 import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.Organisasjon;
@@ -74,7 +73,7 @@ class RefusjonOmsorgsdagerServiceTest {
 
         var forventetArbeidstakerInfo = new SlåOppArbeidstakerResponse(
             new SlåOppArbeidstakerResponse.Personinformasjon("fornavn", "mellomnavn", "etternavn", "12345678910", aktørId.getAktørId()),
-            List.of(new SlåOppArbeidstakerResponse.ArbeidsforholdDto(orgnummer, "Arbeidsgiver AS", new PeriodeDto(ansettelsesperiode.fom(), ansettelsesperiode.tom()))));
+            List.of(new SlåOppArbeidstakerResponse.ArbeidsforholdDto(orgnummer, "Arbeidsgiver AS", new SlåOppArbeidstakerResponse.Ansettelsesperiode(ansettelsesperiode.fom(), ansettelsesperiode.tom()))));
 
         when(personTjenesteMock.hentPersonFraIdent(fødselsnummer)).thenReturn(new PersonInfo("fornavn", "mellomnavn", "etternavn", fødselsnummer, aktørId, LocalDate.now(), null, Kjønn.KVINNE));
         when(arbeidstakerTjenesteMock.finnArbeidsforholdInnsenderHarTilgangTil(fødselsnummer, LocalDate.of(førsteFraværsdag.getYear(), 1, 1), LocalDate.now())).thenReturn(arbeidsforhold);


### PR DESCRIPTION
### Behov / Bakgrunn
Se https://github.com/navikt/k9-inntektsmelding/pull/762

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
