### PR TITLE
Fiks: kvittering for AGI ved første innsending

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingMottakTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingMottakTjeneste.java
@@ -57,7 +57,7 @@ public class InntektsmeldingMottakTjeneste {
             throw new IllegalStateException("Kan ikke motta nye inntektsmeldinger på utgåtte forespørsler");
         }
 
-        int antalleInntektsmeldinger = forespørselEntitet.getInntektsmeldinger().size();
+        int antallInntektsmeldinger = forespørselEntitet.getInntektsmeldinger().size();
 
         var aktorId = new AktørIdEntitet(sendInntektsmeldingRequest.aktorId().id());
         var orgnummer = new OrganisasjonsnummerDto(sendInntektsmeldingRequest.arbeidsgiverIdent().ident());
@@ -65,7 +65,7 @@ public class InntektsmeldingMottakTjeneste {
         var imId = lagreOgLagJournalførTask(inntektsmeldingEntitet, forespørselEntitet);
 
         // ved første im skal vi ferdigstille forespørsel. Ved andre skal vi oppdatere arbeidsgiverportalen og dialogporten
-        if (antalleInntektsmeldinger == 0) {
+        if (antallInntektsmeldinger == 0) {
             var lukketForespørsel = forespørselBehandlingTjeneste.ferdigstillForespørsel(
                 sendInntektsmeldingRequest.foresporselUuid(),
                 aktorId,

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingMottakTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingMottakTjeneste.java
@@ -57,13 +57,15 @@ public class InntektsmeldingMottakTjeneste {
             throw new IllegalStateException("Kan ikke motta nye inntektsmeldinger på utgåtte forespørsler");
         }
 
+        var antalleInntektsmeldinger = forespørselEntitet.getInntektsmeldinger().size();
+
         var aktorId = new AktørIdEntitet(sendInntektsmeldingRequest.aktorId().id());
         var orgnummer = new OrganisasjonsnummerDto(sendInntektsmeldingRequest.arbeidsgiverIdent().ident());
         var inntektsmeldingEntitet = InntektsmeldingMapper.mapTilEntitet(sendInntektsmeldingRequest, forespørselEntitet);
         var imId = lagreOgLagJournalførTask(inntektsmeldingEntitet, forespørselEntitet);
 
         // ved første im skal vi ferdigstille forespørsel. Ved andre skal vi oppdatere arbeidsgiverportalen og dialogporten
-        if (forespørselEntitet.getInntektsmeldinger().size() == 1) {
+        if (antalleInntektsmeldinger == 0) {
             var lukketForespørsel = forespørselBehandlingTjeneste.ferdigstillForespørsel(
                 sendInntektsmeldingRequest.foresporselUuid(),
                 aktorId,
@@ -137,13 +139,15 @@ public class InntektsmeldingMottakTjeneste {
         var forespørselEntitet = forespørselBehandlingTjeneste.hentForespørsel(forespørselUuid)
             .orElseThrow(this::manglerForespørselFeil);
 
+        var antallInntektsmeldinger = forespørselEntitet.getInntektsmeldinger().size();
+
         var inntektsmeldingEntitet = InntektsmeldingMapper.mapTilEntitetForArbeidsgiverinitiertNyansatt(request, forespørselEntitet);
         var inntektsmeldingId = lagreOgLagJournalførTask(inntektsmeldingEntitet, forespørselEntitet);
 
         MetrikkerTjeneste.loggInnsendtAGIRefusjonNyansatt(inntektsmeldingEntitet);
 
         // ved første im skal vi ferdigstille forespørsel. Ved andre skal vi oppdatere arbeidsgiverportalen og dialogporten
-        if (forespørselEntitet.getInntektsmeldinger().size() == 1) {
+        if (antallInntektsmeldinger == 0) {
             forespørselBehandlingTjeneste.ferdigstillForespørsel(forespørselUuid,
                 aktørId,
                 organisasjonsnummer,
@@ -178,13 +182,15 @@ public class InntektsmeldingMottakTjeneste {
         var forespørselEntitet = forespørselBehandlingTjeneste.hentForespørsel(forespørselUuid)
             .orElseThrow(this::manglerForespørselFeil);
 
+        var antallInntektsmeldinger = forespørselEntitet.getInntektsmeldinger().size();
+
         var inntektsmeldingEntitet = InntektsmeldingMapper.mapTilEntitet(request, forespørselEntitet);
         var inntektsmeldingId = lagreOgLagJournalførTask(inntektsmeldingEntitet, forespørselEntitet);
 
         MetrikkerTjeneste.loggInnsendtAGIUregistrert(inntektsmeldingEntitet);
 
         // ved første im skal vi ferdigstille forespørsel. Ved andre skal vi oppdatere arbeidsgiverportalen og dialogporten
-        if (forespørselEntitet.getInntektsmeldinger().size() == 1) {
+        if (antallInntektsmeldinger == 0) {
             forespørselBehandlingTjeneste.ferdigstillForespørsel(
                 forespørselUuid,
                 aktørId,

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingMottakTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingMottakTjeneste.java
@@ -57,7 +57,7 @@ public class InntektsmeldingMottakTjeneste {
             throw new IllegalStateException("Kan ikke motta nye inntektsmeldinger på utgåtte forespørsler");
         }
 
-        var antalleInntektsmeldinger = forespørselEntitet.getInntektsmeldinger().size();
+        int antalleInntektsmeldinger = forespørselEntitet.getInntektsmeldinger().size();
 
         var aktorId = new AktørIdEntitet(sendInntektsmeldingRequest.aktorId().id());
         var orgnummer = new OrganisasjonsnummerDto(sendInntektsmeldingRequest.arbeidsgiverIdent().ident());
@@ -139,7 +139,7 @@ public class InntektsmeldingMottakTjeneste {
         var forespørselEntitet = forespørselBehandlingTjeneste.hentForespørsel(forespørselUuid)
             .orElseThrow(this::manglerForespørselFeil);
 
-        var antallInntektsmeldinger = forespørselEntitet.getInntektsmeldinger().size();
+        int antallInntektsmeldinger = forespørselEntitet.getInntektsmeldinger().size();
 
         var inntektsmeldingEntitet = InntektsmeldingMapper.mapTilEntitetForArbeidsgiverinitiertNyansatt(request, forespørselEntitet);
         var inntektsmeldingId = lagreOgLagJournalførTask(inntektsmeldingEntitet, forespørselEntitet);
@@ -182,7 +182,7 @@ public class InntektsmeldingMottakTjeneste {
         var forespørselEntitet = forespørselBehandlingTjeneste.hentForespørsel(forespørselUuid)
             .orElseThrow(this::manglerForespørselFeil);
 
-        var antallInntektsmeldinger = forespørselEntitet.getInntektsmeldinger().size();
+        int antallInntektsmeldinger = forespørselEntitet.getInntektsmeldinger().size();
 
         var inntektsmeldingEntitet = InntektsmeldingMapper.mapTilEntitet(request, forespørselEntitet);
         var inntektsmeldingId = lagreOgLagJournalførTask(inntektsmeldingEntitet, forespørselEntitet);

--- a/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingMottakTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imdialog/tjenester/InntektsmeldingMottakTjenesteTest.java
@@ -27,7 +27,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
 import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselMapper;
 import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
-import no.nav.familie.inntektsmelding.forespørsel.tjenester.LukkeÅrsak;
 import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingEntitet;
 import no.nav.familie.inntektsmelding.imdialog.modell.InntektsmeldingRepository;
 import no.nav.familie.inntektsmelding.imdialog.modell.KontaktpersonEntitet;
@@ -98,24 +97,6 @@ class InntektsmeldingMottakTjenesteTest {
 
         // Assert
         assertThat(ex.getMessage()).contains("Kan ikke motta nye inntektsmeldinger på utgåtte forespørsler");
-    }
-
-    @Test
-    void skal_ferdigstille_forespørsel_ved_første_innsending() {
-        // Arrange
-        var forespørsel = spy(lagForespørsel());
-        var lagretIm = lagInntektsmeldingEntitet(forespørsel);
-        when(forespørsel.getInntektsmeldinger()).thenReturn(List.of(lagretIm)); // size == 1 → første innsending
-        when(forespørselBehandlingTjeneste.hentForespørsel(FORESPORSEL_UUID)).thenReturn(Optional.of(forespørsel));
-        when(forespørselBehandlingTjeneste.ferdigstillForespørsel(any(), any(), any(), any(), any())).thenReturn(forespørsel);
-        stubLagring(lagretIm);
-
-        // Act
-        inntektsmeldingMottakTjeneste.mottaInntektsmelding(lagRequest());
-
-        // Assert
-        verify(forespørselBehandlingTjeneste).ferdigstillForespørsel(eq(FORESPORSEL_UUID), any(), any(), eq(LukkeÅrsak.ORDINÆR_INNSENDING), any());
-        verify(forespørselBehandlingTjeneste, never()).oppdaterPortalerMedEndretInntektsmelding(any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
### Behov / Bakgrunn
Lazy loading av inntektsmeldinger på forespørselen gjør at sjekken for om vi skal ferdigstlle forespørselen eller oppdatere den ikke blir helt riktig.

### Løsning
Henter ut antall inntektsmeldinger før vi lagrer den nye inntektsmeldingen sammen med forespørselen

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
