### PR TITLE
Fiks: utled riktig merkelapp ved ferdigstilling av oms refusjon

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -121,7 +121,7 @@ public class ForespørselBehandlingTjeneste {
         forespørselTjeneste.ferdigstillForespørsel(forespørsel.getArbeidsgiverNotifikasjonSakId()); // Oppdaterer status i forespørsel
 
         if (inntektsmeldingEntitet.isPresent()) {
-            var merkelapp = ForespørselTekster.finnMerkelapp(forespørsel.getYtelseType());
+            var merkelapp = ForespørselTekster.finnMerkelapp(forespørsel.getYtelseType(), forespørsel.getForespørselType());
             var beskjedTekst = ForespørselTekster.lagBeskjedOmKvitteringFørsteInnsendingTekst();
             var hentInntektsmeldingPdfUrl = arbeidsgiverportalSkjemaLenke + "/server/api" + PdfDokumentRest.INNTEKTSMELDING_FULL_PATH + "/" + inntektsmeldingEntitet.get().getUuid();
             minSideArbeidsgiverTjeneste.sendNyBeskjedMedKvittering(forespørsel.getUuid().toString(),
@@ -380,7 +380,7 @@ public class ForespørselBehandlingTjeneste {
             etterspurtePerioder,
             forespørselType);
 
-        opprettForespørselMinSideArbeidsgiver(ytelsetype, aktørId, organisasjonsnummer, skjæringstidspunkt, etterspurtePerioder, forespørselUuid);
+        opprettForespørselMinSideArbeidsgiver(ytelsetype, aktørId, organisasjonsnummer, skjæringstidspunkt, etterspurtePerioder, forespørselUuid, forespørselType);
 
         if (dialogportenEnabled) {
             try {
@@ -397,10 +397,11 @@ public class ForespørselBehandlingTjeneste {
                                                        OrganisasjonsnummerDto organisasjonsnummer,
                                                        LocalDate skjæringstidspunkt,
                                                        List<PeriodeDto> etterspurtePerioder,
-                                                       UUID forespørselUuid) {
+                                                       UUID forespørselUuid,
+                                                       ForespørselType forespørselType) {
         var organisasjon = organisasjonTjeneste.finnOrganisasjon(organisasjonsnummer.orgnr());
         var person = personTjeneste.hentPersonInfoFraAktørId(aktørId);
-        var merkelapp = ForespørselTekster.finnMerkelapp(ytelsetype);
+        var merkelapp = ForespørselTekster.finnMerkelapp(ytelsetype, forespørselType);
         var skjemaUri = URI.create(arbeidsgiverportalSkjemaLenke + "/" + forespørselUuid);
         var arbeidsgiverNotifikasjonSakId = minSideArbeidsgiverTjeneste.opprettSak(forespørselUuid.toString(),
             merkelapp,
@@ -453,7 +454,7 @@ public class ForespørselBehandlingTjeneste {
                                                          Optional<UUID> inntektsmeldingUuid) {
         // Oppdater status i arbeidsgiverportalen
         if (inntektsmeldingUuid.isPresent()) {
-            var merkelapp = ForespørselTekster.finnMerkelapp(forespørsel.getYtelseType());
+            var merkelapp = ForespørselTekster.finnMerkelapp(forespørsel.getYtelseType(), forespørsel.getForespørselType());
             var beskjedTekst = ForespørselTekster.lagBeskjedOmOppdatertInntektsmelding();
             var hentInntektsmeldingPdfUrl = arbeidsgiverportalSkjemaLenke + "/server/api" + PdfDokumentRest.INNTEKTSMELDING_FULL_PATH + "/" + inntektsmeldingUuid.get();
             minSideArbeidsgiverTjeneste.sendNyBeskjedMedKvittering(forespørsel.getUuid().toString(),
@@ -488,7 +489,7 @@ public class ForespørselBehandlingTjeneste {
 
         // opprett sak på min side arbeidsgiver
         var person = personTjeneste.hentPersonInfoFraAktørId(aktørId);
-        var merkelapp = ForespørselTekster.finnMerkelapp(ytelsetype);
+        var merkelapp = ForespørselTekster.finnMerkelapp(ytelsetype, forespørselType);
         var inntektsmeldingOppsummeringsUri = lagUriForInntektsmeldingOppsummering(forespørselUuid);
         var sakstittel = ForespørselTekster.lagSaksTittelInntektsmelding(person.mapFulltNavn(), person.fødselsdato());
         var arbeidsgiverNotifikasjonSakId = minSideArbeidsgiverTjeneste.opprettSak(forespørselUuid.toString(), merkelapp, organisasjonsnummer.orgnr(), sakstittel, inntektsmeldingOppsummeringsUri);
@@ -642,7 +643,7 @@ public class ForespørselBehandlingTjeneste {
     }
 
     public void opprettNyBeskjedMedEksternVarsling(ForespørselEntitet forespørsel) {
-        Merkelapp merkelapp = ForespørselTekster.finnMerkelapp(forespørsel.getYtelseType());
+        Merkelapp merkelapp = ForespørselTekster.finnMerkelapp(forespørsel.getYtelseType(), forespørsel.getForespørselType());
         UUID forespørselUuid = forespørsel.getUuid();
         URI hentInntektsmeldingPdfUri = URI.create(arbeidsgiverportalSkjemaLenke + "/" + forespørselUuid);
         Organisasjon organisasjon = organisasjonTjeneste.finnOrganisasjon(forespørsel.getOrganisasjonsnummer());

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTekster.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselTekster.java
@@ -19,6 +19,7 @@ import no.nav.familie.inntektsmelding.imdialog.modell.DelvisFraværsPeriodeEntit
 import no.nav.familie.inntektsmelding.imdialog.modell.FraværsPeriodeEntitet;
 import no.nav.familie.inntektsmelding.integrasjoner.arbeidsgivernotifikasjon.Merkelapp;
 import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.Organisasjon;
+import no.nav.familie.inntektsmelding.koder.ForespørselType;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.typer.dto.PeriodeDto;
 
@@ -165,12 +166,14 @@ public class ForespørselTekster {
         return Arrays.stream(input.toLowerCase().split("\\s+")).map(StringUtils::capitalize).collect(Collectors.joining(" "));
     }
 
-    public static Merkelapp finnMerkelapp(Ytelsetype ytelsetype) {
+    public static Merkelapp finnMerkelapp(Ytelsetype ytelsetype, ForespørselType forespørselType) {
         return switch (ytelsetype) {
             case PLEIEPENGER_SYKT_BARN -> Merkelapp.INNTEKTSMELDING_PSB;
-            case OMSORGSPENGER -> Merkelapp.INNTEKTSMELDING_OMP;
             case PLEIEPENGER_NÆRSTÅENDE -> Merkelapp.INNTEKTSMELDING_PILS;
             case OPPLÆRINGSPENGER -> Merkelapp.INNTEKTSMELDING_OPP;
+            case OMSORGSPENGER -> forespørselType == ForespørselType.OMSORGSPENGER_REFUSJON
+                                  ? Merkelapp.REFUSJONSKRAV_OMP
+                                  : Merkelapp.INNTEKTSMELDING_OMP;
         };
     }
 


### PR DESCRIPTION
### Behov / Bakgrunn
Vi får ikke opprettet kvittering med pdf for omsorgspenger refusjon. Det er litt usikkert hvorfor det ikke fungerer, for det er ingenting som feiler i loggene mot fager, men det kan være fordi vi ikke utleder riktig merkelapp for omsorgspenger refusjon. Uansett så burde det fikses.

### Løsning
Finn merkelapp tar nå hensyn til om forespørsel type er OMSORGSPENGER_REFUSJON

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
