### PR TITLE
TSFF-2837: Ny kontrakt for omsorgspenger refusjon for inntektsmelding-api

### DIFF
--- a/kontrakter/src/main/java/no/nav/k9/inntektsmelding/felles/FeilInfo.java
+++ b/kontrakter/src/main/java/no/nav/k9/inntektsmelding/felles/FeilInfo.java
@@ -1,0 +1,5 @@
+package no.nav.k9.inntektsmelding.felles;
+
+public record FeilInfo(FeilkodeDto feilkode,
+                       String feilmelding,
+                       String referanseId) {}

--- a/kontrakter/src/main/java/no/nav/k9/inntektsmelding/felles/OmsorgspengerDto.java
+++ b/kontrakter/src/main/java/no/nav/k9/inntektsmelding/felles/OmsorgspengerDto.java
@@ -12,29 +12,12 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public record OmsorgspengerDto(@NotNull Boolean harUtbetaltPliktigeDager,
-                               List<@Valid FraværHeleDagerDto> fraværHeleDager,
-                               List<@Valid FraværDelerAvDagenDto> fraværDelerAvDagen) {
+                               List<@Valid PeriodeDto> fraværHeleDager,
+                               List<@Valid FraværDelerAvDagenDto> fraværDelerAvDagen,
+                               List<@Valid PeriodeDto> trukketPerioder) {
 
     public record FraværDelerAvDagenDto(@NotNull LocalDate dato,
                                         @NotNull @Min(0) @Max(24) @Digits(integer = 2, fraction = 2) BigDecimal timer) {
-    }
-
-    public record FraværHeleDagerDto(@NotNull LocalDate fom,
-                                     @NotNull LocalDate tom) {
-
-        @AssertTrue(message = "fom er før eller lik tom")
-        private boolean isValidFomErFørTom() {
-            return fom.isBefore(tom) || fom.isEqual(tom);
-        }
-
-        private boolean overlapper(FraværHeleDagerDto annen) {
-            return (fom.isBefore(annen.tom) || fom.isEqual(annen.tom)) &&
-                (tom.isAfter(annen.fom) || tom.isEqual(annen.fom));
-        }
-
-        private boolean inneholder(LocalDate dato) {
-            return (fom.isBefore(dato) || fom.isEqual(dato)) && (tom.isAfter(dato) || tom.isEqual(dato));
-        }
     }
 
     @AssertTrue(message = "Ingen fraværHeleDager overlapper")
@@ -65,14 +48,36 @@ public record OmsorgspengerDto(@NotNull Boolean harUtbetaltPliktigeDager,
         }
         return fraværHeleDager.stream()
             .noneMatch(heldag -> fraværDelerAvDagen.stream()
-                .anyMatch(delvis -> heldag.inneholder(delvis.dato())));
+                .anyMatch(delvis -> heldag.inneholderDato(delvis.dato())));
     }
 
-    @AssertTrue(message = "Må ha enten fraværHeleDager eller fraværDelerAvDagen")
-    private boolean isValidHarFraværsperioder() {
-        if (fraværHeleDager == null || fraværHeleDager.isEmpty()) {
-            return !(fraværDelerAvDagen == null || fraværDelerAvDagen.isEmpty());
+    @AssertTrue(message = "Ingen dato i trukketPerioder kan finnes i fraværHeleDager eller fraværDelerAvDagen")
+    private boolean isValidIngenOverlappTrukketPerioder() {
+        if (trukketPerioder == null || trukketPerioder.isEmpty()) {
+            return true;
+        }
+        if (fraværHeleDager != null) {
+            for (PeriodeDto trukket : trukketPerioder) {
+                if (fraværHeleDager.stream().anyMatch(heldag -> heldag.overlapper(trukket))) {
+                    return false;
+                }
+            }
+        }
+        if (fraværDelerAvDagen != null) {
+            for (PeriodeDto trukket : trukketPerioder) {
+                if (fraværDelerAvDagen.stream().anyMatch(delvis -> trukket.inneholderDato(delvis.dato()))) {
+                    return false;
+                }
+            }
         }
         return true;
+    }
+
+    @AssertTrue(message = "Må ha enten fraværHeleDager, fraværDelerAvDagen eller trukketPerioder")
+    private boolean isValidHarFraværsperioder() {
+        boolean harFraværHeleDager = fraværHeleDager != null && !fraværHeleDager.isEmpty();
+        boolean harFraværDelerAvDagen = fraværDelerAvDagen != null && !fraværDelerAvDagen.isEmpty();
+        boolean harTrukketPerioder = trukketPerioder != null && !trukketPerioder.isEmpty();
+        return harFraværHeleDager || harFraværDelerAvDagen || harTrukketPerioder;
     }
 }

--- a/kontrakter/src/main/java/no/nav/k9/inntektsmelding/felles/PeriodeDto.java
+++ b/kontrakter/src/main/java/no/nav/k9/inntektsmelding/felles/PeriodeDto.java
@@ -10,10 +10,15 @@ public record PeriodeDto(@NotNull LocalDate fom,
 
     @AssertTrue(message = "fom dato må være før eller lik tom dato")
     private boolean isValid() {
-        return fom.isBefore(tom) || fom.isEqual(tom);
+        return fom != null && tom != null && (fom.isBefore(tom) || fom.isEqual(tom));
     }
 
     public boolean inneholderDato(LocalDate dato) {
         return (dato.isEqual(fom) || dato.isAfter(fom)) && (dato.isEqual(tom) || dato.isBefore(tom));
+    }
+
+    boolean overlapper(PeriodeDto annen) {
+        return (fom.isBefore(annen.tom) || fom.isEqual(annen.tom)) &&
+            (tom.isAfter(annen.fom) || tom.isEqual(annen.fom));
     }
 }

--- a/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/inntektsmelding/SendInntektsmeldingResponse.java
+++ b/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/inntektsmelding/SendInntektsmeldingResponse.java
@@ -2,8 +2,9 @@ package no.nav.k9.inntektsmelding.imapi.inntektsmelding;
 
 import java.util.UUID;
 
-import no.nav.k9.inntektsmelding.felles.FeilkodeDto;
+import no.nav.k9.inntektsmelding.felles.FeilInfo;
 
-public record SendInntektsmeldingResponse(boolean success, UUID inntektsmeldingUuid, FeilInfo feilinformasjon) {
-    public record FeilInfo(FeilkodeDto feilkode, String feilmelding, String referanseId) {}
+public record SendInntektsmeldingResponse(boolean success,
+                                          UUID inntektsmeldingUuid,
+                                          FeilInfo feilinformasjon) {
 }

--- a/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/inntektsmelding/SendRefusjonOmsorgspengerRequest.java
+++ b/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/inntektsmelding/SendRefusjonOmsorgspengerRequest.java
@@ -1,0 +1,28 @@
+package no.nav.k9.inntektsmelding.imapi.inntektsmelding;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import no.nav.k9.inntektsmelding.felles.AvsenderSystemDto;
+import no.nav.k9.inntektsmelding.felles.EndringsårsakerDto;
+import no.nav.k9.inntektsmelding.felles.FødselsnummerDto;
+import no.nav.k9.inntektsmelding.felles.KontaktpersonDto;
+import no.nav.k9.inntektsmelding.felles.OmsorgspengerDto;
+import no.nav.k9.inntektsmelding.felles.OrganisasjonsnummerDto;
+
+public record SendRefusjonOmsorgspengerRequest(@NotNull @Valid FødselsnummerDto fødselsnummer,
+                                               @NotNull @Valid OrganisasjonsnummerDto organisasjonsnummer,
+                                               @NotNull LocalDate startdato,
+                                               @NotNull @Valid KontaktpersonDto kontaktperson,
+                                               @NotNull @Min(0) @Max(Integer.MAX_VALUE) @Digits(integer = 20, fraction = 2) BigDecimal inntekt,
+                                               List<@Valid EndringsårsakerDto> endringAvInntektÅrsaker,
+                                               @NotNull @Valid AvsenderSystemDto avsenderSystem,
+                                               @NotNull @Valid OmsorgspengerDto omsorgspenger) {
+}

--- a/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/inntektsmelding/SendRefusjonOmsorgspengerResponse.java
+++ b/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/inntektsmelding/SendRefusjonOmsorgspengerResponse.java
@@ -1,0 +1,10 @@
+package no.nav.k9.inntektsmelding.imapi.inntektsmelding;
+
+import java.util.UUID;
+
+import no.nav.k9.inntektsmelding.felles.FeilInfo;
+
+public record SendRefusjonOmsorgspengerResponse(boolean success,
+                                                UUID inntektsmeldingUuid,
+                                                FeilInfo feilinformasjon) {
+}


### PR DESCRIPTION
### Behov / Bakgrunn
Se relevant PR:  https://github.com/navikt/k9-inntektsmelding/pull/761

Jira: https://nav.atlassian.net/browse/TSFF-2837

### Løsning
- Trekker ut FeilInfo som en felles komponent som kan brukes av SendInntektsmeldingResponse og SendRefusjonOmsorgspengerResponse. Innholdet er likt, men har opprettet en egen respons type for å følge mønsteret. 
- Innfører trukket periode i OmsorgspengerDto

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
