### PR TITLE
fjerne bigquery dataset

### DIFF
--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -73,10 +73,6 @@ spec:
           - name: "pgaudit.log_parameter"
             value: "on"
         {{/if}}
-    bigQueryDatasets:
-      -  name: k9_inntektsmelding_statistikk_dataset
-         description: Inneholder tabeller for k9-inntektsmelding statistikk
-         permission: READWRITE
   maskinporten:
     enabled: true
     scopes:
@@ -137,8 +133,6 @@ spec:
       value: {{driftGruppeOid}}
     - name: gruppe.oid.saksbehandler
       value: {{saksbehandlerGruppeOid}}
-    - name: BIGQUERY_ENABLED
-      value: "true"
     - name: AUDITLOGGER_ENABLED
       value: "true"
     - name: AUDITLOGGER_VENDOR

--- a/pom.xml
+++ b/pom.xml
@@ -80,11 +80,6 @@
                 <version>${k9-sak.version}</version>
             </dependency>
             <dependency>
-                <groupId>no.nav.k9.felles.integrasjon</groupId>
-                <artifactId>k9-bigquery-klient</artifactId>
-                <version>${k9-felles.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>no.nav.sif.abac</groupId>
                 <artifactId>kontrakt</artifactId>
                 <version>${sif-abac-kontrakt.version}</version>
@@ -161,10 +156,6 @@
         <dependency>
             <groupId>no.nav.k9.sak</groupId>
             <artifactId>kontrakt</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>no.nav.k9.felles.integrasjon</groupId>
-            <artifactId>k9-bigquery-klient</artifactId>
         </dependency>
         <dependency>
             <groupId>no.nav.sif.abac</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,11 @@
                 <version>${k9-sak.version}</version>
             </dependency>
             <dependency>
+                <groupId>no.nav.k9.felles</groupId>
+                <artifactId>k9-felles-log</artifactId>
+                <version>${k9-felles.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>no.nav.sif.abac</groupId>
                 <artifactId>kontrakt</artifactId>
                 <version>${sif-abac-kontrakt.version}</version>
@@ -156,6 +161,10 @@
         <dependency>
             <groupId>no.nav.k9.sak</groupId>
             <artifactId>kontrakt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.k9.felles</groupId>
+            <artifactId>k9-felles-log</artifactId>
         </dependency>
         <dependency>
             <groupId>no.nav.sif.abac</groupId>


### PR DESCRIPTION
### Behov / Bakgrunn
Bigquery integrajon ble fjernet her: https://github.com/navikt/k9-inntektsmelding/pull/709 men det ligger noen rester og tabeller i prod og dev.

### Løsning
Fjerner rester. Ersatter med k9-felles-log som ble brukt transitivt via bigquery integrasjonen.

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
