### PR TITLE
TSFF-2877: OMS inntektsmelding skal ikke kunne endre etterspurte perioder (kontrakt)

### DIFF
--- a/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/inntektsmelding/SendInntektsmeldingRequest.java
+++ b/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/inntektsmelding/SendInntektsmeldingRequest.java
@@ -32,15 +32,5 @@ public record SendInntektsmeldingRequest(@NotNull @Valid UUID foresporselUuid,
                                          List<@Valid RefusjonDto> refusjon,
                                          List<@Valid BortfaltNaturalytelseDto> bortfaltNaturalytelsePerioder,
                                          List<@Valid EndringsårsakerDto> endringAvInntektÅrsaker,
-                                         @NotNull @Valid AvsenderSystemDto avsenderSystem,
-                                         @Valid OmsorgspengerDto omsorgspenger) {
-
-    @AssertTrue(message = "ytelseType omsorgspenger må ha omsorgspengerDto")
-    private boolean isValidOmsorgspengerInfo() {
-        if (YtelseTypeDto.OMSORGSPENGER.equals(ytelseType)) {
-            return omsorgspenger != null;
-        } else {
-            return omsorgspenger == null;
-        }
-    }
+                                         @NotNull @Valid AvsenderSystemDto avsenderSystem) {
 }


### PR DESCRIPTION
### Behov / Bakgrunn
Ved opprettelse av forespørsel ber k9 om etterspurte perioder for omsorgspenger. Ved innsending av IM skal ikke arbeidsgiver kunne endre periodene. Dette gjelder allerede på min side arbeidsgiver, men skal også gjelde for LPS som bruker inntekstmelding-apiet.

### Løsning
Fjerner omsorgspenger fra kontrakten 

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
