### PR TITLE
TSFF-2877: OMS inntektsmelding skal ikke kunne endre etterspurte perioder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <k9-inntektsmelding-kontrakt.version>0.1.4</k9-inntektsmelding-kontrakt.version>
+        <k9-inntektsmelding-kontrakt.version>0.1.5</k9-inntektsmelding-kontrakt.version>
         <felles.version>7.8.6</felles.version>
         <prosesstask.version>5.2.7</prosesstask.version>
         <fp-kontrakter.version>9.4.37</fp-kontrakter.version>

--- a/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMapper.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMapper.java
@@ -94,8 +94,8 @@ class InntektsmeldingApiMapper {
             .medLpsSystemInfo(mapAvsenderSystem(request.avsenderSystem()))
             .medForespørsel(forespørsel);
 
-        if (request.omsorgspenger() != null) {
-            builder.medOmsorgspenger(mapOmsorgspenger(request.omsorgspenger()));
+        if(request.ytelseType() == YtelseTypeDto.OMSORGSPENGER) {
+            builder.medOmsorgspenger(mapOmsorgspengerFraForespørsel(forespørsel.getEtterspurtePerioder()));
         }
 
         return builder.build();
@@ -234,6 +234,19 @@ class InntektsmeldingApiMapper {
                 .medTom(endringsårsak.tom())
                 .medBleKjentFra(endringsårsak.bleKjentFom())
                 .build())
+            .toList();
+    }
+
+    private static OmsorgspengerEntitet mapOmsorgspengerFraForespørsel(List<no.nav.familie.inntektsmelding.typer.dto.PeriodeDto> etterspurtePerioder) {
+        return OmsorgspengerEntitet.builder()
+            .medHarUtbetaltPliktigeDager(true) // Forespørsel fra omsorgspenger har alltid betalt pliktige dager
+            .medFraværsPerioder(mapPerioder(etterspurtePerioder))
+            .build();
+    }
+
+    private static List<FraværsPeriodeEntitet> mapPerioder(List<no.nav.familie.inntektsmelding.typer.dto.PeriodeDto> etterspurtePerioder) {
+        return etterspurtePerioder.stream()
+            .map(fraværsPeriode -> new FraværsPeriodeEntitet(PeriodeEntitet.fraOgMedTilOgMed(fraværsPeriode.fom(), fraværsPeriode.tom())))
             .toList();
     }
 

--- a/src/test/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMapperTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMapperTest.java
@@ -42,6 +42,38 @@ class InntektsmeldingApiMapperTest {
     private static final BigDecimal INNTEKT = new BigDecimal("50000");
 
     @Test
+    void mapTilEntitet_omsorgspenger_fraværsperioder_hentes_fra_forespørsel_og_ikke_fra_request() {
+        var periode1 = new no.nav.familie.inntektsmelding.typer.dto.PeriodeDto(
+            LocalDate.of(2024, 3, 1), LocalDate.of(2024, 3, 5));
+        var periode2 = new no.nav.familie.inntektsmelding.typer.dto.PeriodeDto(
+            LocalDate.of(2024, 3, 10), LocalDate.of(2024, 3, 12));
+
+        var forespørsel = ForespørselEntitet.builder()
+            .medOrganisasjonsnummer("999999999")
+            .medSkjæringstidspunkt(STARTDATO)
+            .medAktørId(AKTØR_ID)
+            .medYtelseType(Ytelsetype.OMSORGSPENGER)
+            .medForespørselType(ForespørselType.OMSORGSPENGER_REFUSJON)
+            .medEtterspurtePerioder(List.of(periode1, periode2))
+            .build();
+
+        // request inneholder ingen omsorgspenger-data — entiteten skal likevel få fraværsperiodene fra forespørselen
+        var request = lagRequestInntektsmelding(null, null, null);
+        var entitet = InntektsmeldingApiMapper.mapTilEntitet(request, AKTØR_ID, forespørsel);
+
+        var omsorgspenger = entitet.getOmsorgspenger();
+        assertThat(omsorgspenger).isNotNull();
+        assertThat(omsorgspenger.isHarUtbetaltPliktigeDager()).isTrue();
+
+        var fraværsPerioder = omsorgspenger.getFraværsPerioder();
+        assertThat(fraværsPerioder).hasSize(2);
+        assertThat(fraværsPerioder.stream().map(fp -> fp.getPeriode().getFom()).toList())
+            .containsExactlyInAnyOrder(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 3, 10));
+        assertThat(fraværsPerioder.stream().map(fp -> fp.getPeriode().getTom()).toList())
+            .containsExactlyInAnyOrder(LocalDate.of(2024, 3, 5), LocalDate.of(2024, 3, 12));
+    }
+
+    @Test
     void mapTilEntitet_med_null_refusjon_gir_ingen_npe_og_tom_liste() {
         var request = lagRequestInntektsmelding(null, null, null);
         var forespørsel = lagForespørsel();

--- a/src/test/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMapperTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMapperTest.java
@@ -135,12 +135,6 @@ class InntektsmeldingApiMapperTest {
         List<no.nav.k9.inntektsmelding.felles.BortfaltNaturalytelseDto> bortfalte,
         List<no.nav.k9.inntektsmelding.felles.EndringsårsakerDto> endringsårsaker) {
 
-        var omsorgspenger = new OmsorgspengerDto(
-            true,
-            List.of(new PeriodeDto(STARTDATO, STARTDATO.plusDays(2))),
-            List.of(),
-            List.of()
-        );
         return new SendInntektsmeldingRequest(
             UUID.randomUUID(),
             new FødselsnummerDto("12345678901"),
@@ -152,8 +146,7 @@ class InntektsmeldingApiMapperTest {
             refusjon,
             bortfalte,
             endringsårsaker,
-            new AvsenderSystemDto("TestSystem", "1.0"),
-            omsorgspenger
+            new AvsenderSystemDto("TestSystem", "1.0")
         );
     }
 

--- a/src/test/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMottakTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMottakTjenesteTest.java
@@ -287,8 +287,7 @@ class InntektsmeldingApiMottakTjenesteTest {
             List.of(),
             List.of(),
             List.of(),
-            new AvsenderSystemDto("TestSystem", "1.0"),
-            null
+            new AvsenderSystemDto("TestSystem", "1.0")
         );
     }
 
@@ -304,18 +303,11 @@ class InntektsmeldingApiMottakTjenesteTest {
             List.of(),
             List.of(),
             List.of(new EndringsårsakerDto(EndringsårsakDto.TARIFFENDRING, null, null, null)),
-            new AvsenderSystemDto("TestSystem", "1.0"),
-            null
+            new AvsenderSystemDto("TestSystem", "1.0")
         );
     }
 
     private SendInntektsmeldingRequest lagRequestMedOmsorgspenger() {
-        var omsorgspenger = new OmsorgspengerDto(
-            true,
-            List.of(new PeriodeDto(STARTDATO, STARTDATO.plusDays(2))),
-            List.of(),
-            null
-        );
         return new SendInntektsmeldingRequest(
             FORESPORSEL_UUID,
             new FødselsnummerDto(FNR),
@@ -327,8 +319,7 @@ class InntektsmeldingApiMottakTjenesteTest {
             List.of(),
             List.of(),
             List.of(),
-            new AvsenderSystemDto("TestSystem", "1.0"),
-            omsorgspenger
+            new AvsenderSystemDto("TestSystem", "1.0")
         );
     }
 

--- a/src/test/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiRestTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiRestTest.java
@@ -188,7 +188,6 @@ class InntektsmeldingApiRestTest {
             List.of(),
             List.of(),
             List.of(),
-            null,
             null
         );
     }


### PR DESCRIPTION
### Behov / Bakgrunn
Ved opprettelse av forespørsel ber k9 om etterspurte perioder for omsorgspenger. Ved innsending av IM skal ikke arbeidsgiver kunne endre periodene. Dette gjelder allerede på min side arbeidsgiver, men skal også gjelde for LPS som bruker inntekstmelding-apiet.

### Løsning
- Bruk ny kontrakt
- Utled omsorgspenger fraværperioder fra etterspurte perioder (som ligger på forespørselen)

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
