### PR TITLE
TSFF-2881: Fjern .ekstern i redirect urler i prod

### DIFF
--- a/src/main/resources/application-prod-gcp.properties
+++ b/src/main/resources/application-prod-gcp.properties
@@ -1,9 +1,9 @@
 context.path=/k9/inntektsmelding
 inntektsmelding.skjema.lenke=https://arbeidsgiver.nav.no/k9-im-dialog
 
-foresporsel.api.lenke=https://k9-inntektsmelding-api.ekstern.nav.no/v1/forespoersel
-inntektsmelding.api.lenke=https://k9-inntektsmelding-api.ekstern.nav.no/v1/inntektsmelding/send-inn
-inntektsmelding.hent.api.lenke=https://k9-inntektsmelding-api.ekstern.nav.no/v1/inntektsmelding/hent
+foresporsel.api.lenke=https://k9-inntektsmelding-api.nav.no/v1/forespoersel
+inntektsmelding.api.lenke=https://k9-inntektsmelding-api.nav.no/v1/inntektsmelding/send-inn
+inntektsmelding.hent.api.lenke=https://k9-inntektsmelding-api.nav.no/v1/inntektsmelding/hent
 
 #Swagger er kun tilgjengelig i dev, legger derfor inn dev lenke her
 inntektsmelding.dokumentasjon.lenke=https://k9-inntektsmelding-api.ekstern.dev.nav.no/swagger


### PR DESCRIPTION
### Behov / Bakgrunn
Foreldrepenger oppdaget at url-ene med .ekstern ikke fungerer

### Løsning
Fjerner .ekstern

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
