### PR TITLE
TSFF-2885: Utvid kontrakt med loepenr for forespørsel og inntektsmelding

### DIFF
--- a/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/forespørsel/ForespørselDto.java
+++ b/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/forespørsel/ForespørselDto.java
@@ -11,7 +11,8 @@ import no.nav.k9.inntektsmelding.felles.OrganisasjonsnummerDto;
 import no.nav.k9.inntektsmelding.felles.PeriodeDto;
 import no.nav.k9.inntektsmelding.felles.YtelseTypeDto;
 
-public record ForespørselDto(UUID forespørselUuid,
+public record ForespørselDto(Long loepenr,
+                             UUID forespørselUuid,
                              OrganisasjonsnummerDto orgnummer,
                              FødselsnummerDto fødselsnummer,
                              LocalDate skjæringstidspunkt,

--- a/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/forespørsel/HentForespørselerRequest.java
+++ b/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/forespørsel/HentForespørselerRequest.java
@@ -15,6 +15,7 @@ public record HentForespørselerRequest(@NotNull @Valid OrganisasjonsnummerDto o
                                        @Valid ForespørselStatusDto status,
                                        @Valid YtelseTypeDto ytelseType,
                                        LocalDate fom,
-                                       LocalDate tom) {
+                                       LocalDate tom,
+                                       Long loepenr) {
 }
 

--- a/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/inntektsmelding/HentInntektsmeldingerRequest.java
+++ b/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/inntektsmelding/HentInntektsmeldingerRequest.java
@@ -15,5 +15,6 @@ public record HentInntektsmeldingerRequest(@NotNull @Valid OrganisasjonsnummerDt
                                            @Valid YtelseTypeDto ytelseType,
                                            @Valid UUID forespørselUuid,
                                            LocalDate fom,
-                                           LocalDate tom) {
+                                           LocalDate tom,
+                                           Long loepenr) {
 }

--- a/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/inntektsmelding/InntektsmeldingDto.java
+++ b/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/inntektsmelding/InntektsmeldingDto.java
@@ -23,6 +23,7 @@ import no.nav.k9.inntektsmelding.felles.RefusjonDto;
 import no.nav.k9.inntektsmelding.felles.YtelseTypeDto;
 
 public record InntektsmeldingDto(
+    Long loepenr,
     @NotNull UUID inntektsmeldingUuid,
     @NotNull UUID forespørselUuid,
     @NotNull @Valid FødselsnummerDto fnr,


### PR DESCRIPTION
### Behov / Bakgrunn
LPS-leverandørene har behov for å få et løpenummer som de kan bruke til å søke med. 

Jira: https://nav.atlassian.net/browse/TSFF-2885

### Løsning
Utvider kontraktene med loepenr.

### Andre endringer
Ingen

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
