### PR TITLE
Fiks: Redirect lenke skal ha ekstern ikke intern

### DIFF
--- a/src/main/resources/application-dev-gcp.properties
+++ b/src/main/resources/application-dev-gcp.properties
@@ -1,5 +1,5 @@
 context.path=/k9/inntektsmelding
-inntektsmelding.skjema.lenke=https://arbeidsgiver.intern.dev.nav.no/k9-im-dialog
+inntektsmelding.skjema.lenke=https://arbeidsgiver.ekstern.dev.nav.no/k9-im-dialog
 
 foresporsel.api.lenke=https://k9-inntektsmelding-api.ekstern.dev.nav.no/v1/forespoersel
 inntektsmelding.api.lenke=https://k9-inntektsmelding-api.ekstern.dev.nav.no/v1/inntektsmelding/send-inn


### PR DESCRIPTION
### Behov / Bakgrunn
LPS leverandører når ikke .intern url-er.

### Løsning
Bytter til .ekstern

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
