### PR TITLE
TSFF-2902: Utivd kontrakt med inntektsmelding status

### DIFF
--- a/kontrakter/src/main/java/no/nav/k9/inntektsmelding/felles/InntektsmeldingStatusDto.java
+++ b/kontrakter/src/main/java/no/nav/k9/inntektsmelding/felles/InntektsmeldingStatusDto.java
@@ -1,0 +1,7 @@
+package no.nav.k9.inntektsmelding.felles;
+
+public enum InntektsmeldingStatusDto {
+    AVVIST,
+    MOTTATT,
+    GODKJENT,
+}

--- a/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/inntektsmelding/HentInntektsmeldingerRequest.java
+++ b/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/inntektsmelding/HentInntektsmeldingerRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 import no.nav.k9.inntektsmelding.felles.FødselsnummerDto;
+import no.nav.k9.inntektsmelding.felles.InntektsmeldingStatusDto;
 import no.nav.k9.inntektsmelding.felles.OrganisasjonsnummerDto;
 import no.nav.k9.inntektsmelding.felles.YtelseTypeDto;
 
@@ -16,5 +17,6 @@ public record HentInntektsmeldingerRequest(@NotNull @Valid OrganisasjonsnummerDt
                                            @Valid UUID forespørselUuid,
                                            LocalDate fom,
                                            LocalDate tom,
-                                           Long loepenr) {
+                                           Long loepenr,
+                                           InntektsmeldingStatusDto status) {
 }

--- a/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/inntektsmelding/InntektsmeldingDto.java
+++ b/kontrakter/src/main/java/no/nav/k9/inntektsmelding/imapi/inntektsmelding/InntektsmeldingDto.java
@@ -16,6 +16,7 @@ import no.nav.k9.inntektsmelding.felles.AvsenderSystemDto;
 import no.nav.k9.inntektsmelding.felles.BortfaltNaturalytelseDto;
 import no.nav.k9.inntektsmelding.felles.EndringsårsakerDto;
 import no.nav.k9.inntektsmelding.felles.FødselsnummerDto;
+import no.nav.k9.inntektsmelding.felles.InntektsmeldingStatusDto;
 import no.nav.k9.inntektsmelding.felles.KontaktpersonDto;
 import no.nav.k9.inntektsmelding.felles.OmsorgspengerDto;
 import no.nav.k9.inntektsmelding.felles.OrganisasjonsnummerDto;
@@ -39,6 +40,7 @@ public record InntektsmeldingDto(
     List<@Valid RefusjonDto> refusjonsendringer,
     List<@Valid BortfaltNaturalytelseDto> bortfaltNaturalytelsePerioder,
     List<@Valid EndringsårsakerDto> endringAvInntektÅrsaker,
+    @NotNull InntektsmeldingStatusDto status,
     @Valid OmsorgspengerDto omsorgspenger
 ) {
 


### PR DESCRIPTION
### Behov / Bakgrunn
Hvis inntektskomponenten er nede skal vi ta i mot inntektsmeldingen, sette status til MOTTATT og vente med å validere til inntektskomponenten er oppe igjen. Vi må derfor legge til inntektsmelding status så LPS-ene får oversikt over hvilke som ikke er vurdert.

### Løsning
Utvider kontrakten med samme statuser som foreldrepenger bruker. 

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
