### PR TITLE
TSFF-2902: Bruk inntektsmelding status GODKJENT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <k9-inntektsmelding-kontrakt.version>0.1.6</k9-inntektsmelding-kontrakt.version>
+        <k9-inntektsmelding-kontrakt.version>0.1.7</k9-inntektsmelding-kontrakt.version>
         <felles.version>7.9.0</felles.version>
         <prosesstask.version>5.2.7</prosesstask.version>
         <fp-kontrakter.version>9.4.37</fp-kontrakter.version>

--- a/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMapper.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiMapper.java
@@ -32,6 +32,7 @@ import no.nav.k9.inntektsmelding.felles.AvsenderSystemDto;
 import no.nav.k9.inntektsmelding.felles.BortfaltNaturalytelseDto;
 import no.nav.k9.inntektsmelding.felles.EndringsårsakerDto;
 import no.nav.k9.inntektsmelding.felles.FødselsnummerDto;
+import no.nav.k9.inntektsmelding.felles.InntektsmeldingStatusDto;
 import no.nav.k9.inntektsmelding.felles.KontaktpersonDto;
 import no.nav.k9.inntektsmelding.felles.NaturalytelsetypeDto;
 import no.nav.k9.inntektsmelding.felles.OmsorgspengerDto;
@@ -123,6 +124,7 @@ class InntektsmeldingApiMapper {
             mapRefusjonsendringerTilKontrakt(inntektsmelding),
             mapBortfalteNaturalytelserTilKontrakt(inntektsmelding.getBorfalteNaturalYtelser()),
             mapEndringsårsakerTilKontrakt(inntektsmelding.getEndringsårsaker()),
+            InntektsmeldingStatusDto.GODKJENT,
             mapOmsorgspengerTilKontrakt(inntektsmelding.getOmsorgspenger())
         );
     }

--- a/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiTjeneste.java
@@ -23,6 +23,7 @@ import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;
 import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
+import no.nav.k9.inntektsmelding.felles.InntektsmeldingStatusDto;
 import no.nav.k9.inntektsmelding.imapi.inntektsmelding.HentInntektsmeldingerRequest;
 import no.nav.k9.inntektsmelding.imapi.inntektsmelding.InntektsmeldingDto;
 
@@ -82,6 +83,11 @@ public class InntektsmeldingApiTjeneste {
                 LOG.warn("Finner ikke aktørId ved henting av inntektsmelding fra filter, returnerer tom liste");
                 return List.of();
             }
+        }
+
+        // Per nå er alle eksisterende inntektsmeldinger godkjent, men denne må oppdateres når vi håndterer andre tilstander
+        if (request.status() != null && request.status() != InntektsmeldingStatusDto.GODKJENT) {
+            return List.of();
         }
 
         Ytelsetype ytelsetype = request.ytelseType() != null ? mapYtelsetype(request.ytelseType()) : null;

--- a/src/test/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiRestTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/imapi/inntektsmelding/InntektsmeldingApiRestTest.java
@@ -24,6 +24,7 @@ import no.nav.familie.inntektsmelding.typer.entitet.AktørIdEntitet;
 import no.nav.k9.inntektsmelding.felles.AvsenderSystemDto;
 import no.nav.k9.inntektsmelding.felles.FeilkodeDto;
 import no.nav.k9.inntektsmelding.felles.FødselsnummerDto;
+import no.nav.k9.inntektsmelding.felles.InntektsmeldingStatusDto;
 import no.nav.k9.inntektsmelding.felles.KontaktpersonDto;
 import no.nav.k9.inntektsmelding.felles.OmsorgspengerDto;
 import no.nav.k9.inntektsmelding.felles.OrganisasjonsnummerDto;
@@ -115,7 +116,7 @@ class InntektsmeldingApiRestTest {
     void skal_hente_inntektsmeldinger_med_filter() {
         var forespørselUuid = UUID.randomUUID();
         var inntektsmeldingUuid = UUID.randomUUID();
-        var filterRequest = new HentInntektsmeldingerRequest(new OrganisasjonsnummerDto(ORGNUMMER), null, null, null, null, null, null);
+        var filterRequest = new HentInntektsmeldingerRequest(new OrganisasjonsnummerDto(ORGNUMMER), null, null, null, null, null,  null, null);
         var forventetDto = lagInntektsmeldingDto(inntektsmeldingUuid, forespørselUuid);
         when(inntektsmeldingApiTjeneste.hentInntektsmeldinger(filterRequest)).thenReturn(List.of(forventetDto));
 
@@ -173,6 +174,7 @@ class InntektsmeldingApiRestTest {
             List.of(),
             List.of(),
             List.of(),
+            InntektsmeldingStatusDto.GODKJENT,
             null
         );
     }


### PR DESCRIPTION
### Behov / Bakgrunn
Foreldrepenger og sykepenger har async validering av inntekt dersom inntektskomponenten er nede. Vi ønsker også det samme, men begynner med å ta i bruk den nye kontrakten.

Jira: https://nav.atlassian.net/browse/TSFF-2902
Relatert PR: https://github.com/navikt/k9-inntektsmelding-api/pull/64

### Løsning
Setter inntektsmelding status til GODKJENT for alle for nå.

### TODO
Async håndtering av at inntektskomponenten er nede kommer i en senere PR.




---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
