### PR TITLE
Nedgraderer fp-felles pga jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <k9-felles.version>12.0.0</k9-felles.version>
         <k9-sak.version>7.3.1</k9-sak.version>
         <sif-abac-kontrakt.version>1.14.0</sif-abac-kontrakt.version>
-        <fp-graphql.version>1.1.0</fp-graphql.version>
+        <fp-graphql.version>1.0.1</fp-graphql.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <k9-inntektsmelding-kontrakt.version>0.1.6</k9-inntektsmelding-kontrakt.version>
-        <felles.version>7.9.0</felles.version>
+        <felles.version>7.8.6</felles.version>
         <prosesstask.version>5.2.7</prosesstask.version>
         <fp-kontrakter.version>9.4.37</fp-kontrakter.version>
         <k9-felles.version>12.0.0</k9-felles.version>


### PR DESCRIPTION
### Behov / Bakgrunn
no.nav.vedtak.exception.TekniskException: FP-713328: Fikk JacksonException ved deserialisering av JSON
Caused by: tools.jackson.databind.exc.InvalidDefinitionException: Conflicting property-based creators: already had explicit creator [method no.nav.k9.kodeverk.behandling.FagsakYtelseType#fraObjektProp(java.lang.String)], encountered another: [method no.nav.k9.kodeverk.behandling.FagsakYtelseType#fraKode(java.lang.String)]

### Løsning
Nedgraderer til fp-felles v7.8 fordi 7.9 bruker Jackson 3 som er strengere og fører til feilen over.
https://github.com/navikt/fp-felles/releases/tag/7.9.0
https://github.com/navikt/fp-graphql/releases/tag/1.1.0

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
