### PR TITLE
Nytt anbefalt flagg å aktivere for auditlogging fra NAIS

### DIFF
--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -69,7 +69,7 @@ spec:
           - name: "cloudsql.enable_pgaudit"
             value: "on"
           - name: "pgaudit.log"
-            value: "all"
+            value: "read,write,ddl,role,function"
           - name: "pgaudit.log_parameter"
             value: "on"
           - name: "pgaudit.log_relation"

--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -72,6 +72,8 @@ spec:
             value: "all"
           - name: "pgaudit.log_parameter"
             value: "on"
+          - name: "pgaudit.log_relation"
+            value: "on"
         {{/if}}
   maskinporten:
     enabled: true


### PR DESCRIPTION
### Behov / Bakgrunn
NAIS anbefaler nå å sette `pgaudit.log_relation = on` for å dekke noen situasjoner hvor vi ikke auditlogger slik vi burde.

Slack: https://nav-it.slack.com/archives/C01DE3M9YBV/p1787214241846019
Nais docs: https://docs.nais.io/persistence/cloudsql/how-to/enable-auditing/

Vi oppdaget også at ved å bruke `pgaudit.log = all` blir det mye unødvendig logging. Etter sparring med Nais teamet endrer vi til å bruke `read,write,ddl,role,function`

### Løsning
- Legger til `pgaudit.log_relation = on`
- Endrer til `pgaudit.log = read,write,ddl,role,function`

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
